### PR TITLE
Added NatSpec documentation to __kBaseRoles_init in src/base/kBaseRol…

### DIFF
--- a/src/base/kBaseRoles.sol
+++ b/src/base/kBaseRoles.sol
@@ -78,6 +78,15 @@ contract kBaseRoles is OptimizedOwnableRoles {
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Initializes role assignments for the protocol.
+    ///
+    /// @dev Dual-role grants are convenience defaults for testnet deployments:
+    /// - `_admin` is granted both `ADMIN_ROLE` and `VENDOR_ROLE`.
+    /// - `_relayer` is granted both `RELAYER_ROLE` and `MANAGER_ROLE`.
+    ///
+    /// Production deployments should use separate addresses for each role.
+    /// The owner can revoke and re-grant roles to dedicated addresses after
+    /// initialization via `revokeRoles` and `grantRoles`.
     function __kBaseRoles_init(
         address _owner,
         address _admin,

--- a/test/unit/kRegistry.kBaseRoles.t.sol
+++ b/test/unit/kRegistry.kBaseRoles.t.sol
@@ -203,4 +203,30 @@ contract kRegistrykBaseRolesTest is DeploymentBaseTest {
         vm.expectRevert(Ownable.NoHandoverRequest.selector);
         registry.completeOwnershipHandover(users.bob);
     }
+
+    /* //////////////////////////////////////////////////////////////
+                    DUAL-ROLE INITIALIZATION GRANTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Init_AdminAutoGrantedVendorRole() public view {
+        assertTrue(registry.hasAllRoles(users.admin, ADMIN_ROLE | VENDOR_ROLE));
+    }
+
+    function test_Init_RelayerAutoGrantedManagerRole() public view {
+        assertTrue(registry.hasAllRoles(users.relayer, RELAYER_ROLE | MANAGER_ROLE));
+    }
+
+    function test_Init_OwnerCanSeparateRolesAfterInit() public {
+        assertTrue(registry.hasAllRoles(users.admin, ADMIN_ROLE | VENDOR_ROLE));
+
+        vm.prank(users.owner);
+        registry.revokeRoles(users.admin, VENDOR_ROLE);
+        assertFalse(registry.hasAnyRole(users.admin, VENDOR_ROLE));
+        assertTrue(registry.hasAnyRole(users.admin, ADMIN_ROLE));
+
+        vm.prank(users.owner);
+        registry.grantRoles(users.bob, VENDOR_ROLE);
+        assertTrue(registry.hasAnyRole(users.bob, VENDOR_ROLE));
+        assertFalse(registry.hasAnyRole(users.bob, ADMIN_ROLE));
+    }
 }


### PR DESCRIPTION
…es.sol

      explaining that the dual-role grants (admin -> VENDOR_ROLE, relayer -> MANAGER_ROLE)
      are testnet convenience defaults, and production should use separate addresses.