### PR TITLE
Post audit phase 6: timelocks + governance

### DIFF
--- a/docs/timelock-and-governance-spec.md
+++ b/docs/timelock-and-governance-spec.md
@@ -1,0 +1,493 @@
+# Timelock & Governance Specification
+
+**Status**: draft for review
+**Owner**: Phase 6 implementation
+**Predecessor**: [`docs/post-audit-improvement-plan.md`](post-audit-improvement-plan.md) Phase 6
+**Companion**: [`docs/security-design-roles-spec.md`](security-design-roles-spec.md)
+
+---
+
+## Note on sources
+
+This specification derives its patterns and code from **OpenZeppelin Contracts v5.6.1 (MIT-licensed)**, vendored under `src/vendor/openzeppelin/`. The MIT license permits use, modification, and redistribution provided the original copyright notice is preserved (which we do — vendored files retain their original SPDX and OZ headers).
+
+KAM is proprietary code (`SPDX-License-Identifier: UNLICENSED`). We do not derive patterns, code, or architectural details from any licensed protocol other than OpenZeppelin. Architectural decisions in this document originate from the Trail of Bits audit findings, OpenZeppelin's published API and recommended practices, and KAM-specific requirements.
+
+---
+
+## 1. Why this exists
+
+The Trail of Bits audit flagged the protocol as fully centralized: privileged roles can directly affect user assets, and no timelocks exist on any administrative operation. Phase 6 adds two timelocks gating governance and parameter-changing operations, while preserving instant pathways for incident response.
+
+This document is the design contract. Implementation must conform to it. Deviations require an updated revision of this file.
+
+---
+
+## 2. Role architecture
+
+### 2.1 Custody — Fordefi MPC
+
+Every protocol role is a Fordefi MPC wallet. Fordefi provides:
+- Multi-party computation key custody (no single key material exists in plaintext)
+- Per-call policy enforcement at signature time
+- Server share inside AWS Nitro Secure Enclave
+
+Role separation is enforced at the contract level (Solady `OwnableRoles` for KAM contracts; OZ `AccessControl` inside the vendored `TimelockController`); Fordefi enforces signature requirements within each wallet.
+
+### 2.2 Roles and signature requirements
+
+| Role | Signature requirement | Function | Timelocked? |
+|------|----------------------|----------|-------------|
+| `ADMIN` | **x-of-y MPC** (recommended 3-of-5) | Governance: propose to timelocks, hold timelock admin role, role grants/revokes, rescue ops | Yes — for governance ops only |
+| `MANAGER` | **1-of-1 MPC** | Operational: settlement proposals, batch operations, vault tuning within bounds | No — purely operational, never proposes to timelock |
+| `RELAYER` | **1-of-1 MPC** | Settlement bot, autoclaim execution, scheduled tasks | No |
+| `EMERGENCY_ADMIN` | **1-of-1 MPC** | Pause/unpause for incident response | No — instant |
+| `GUARDIAN` | **1-of-1 MPC** | Cancel queued timelock ops, cancel high-yield settlement proposals | No — instant cancel only |
+| `INSTITUTION` | per-institution wallet | Mint/burn kTokens (user role, not governance) | N/A |
+
+### 2.3 Why this split
+
+The split is derived from KAM's own role taxonomy (see [`security-design-roles-spec.md`](security-design-roles-spec.md)), which already separates incident-response (`EMERGENCY_ADMIN`, `GUARDIAN`) from operational (`MANAGER`, `RELAYER`) from governance (`ADMIN`). Phase 6 adds the timelock layer on top of that existing split — the timelock gates governance only; operational and emergency roles are unchanged.
+
+Fast roles must remain instant because they exist for time-critical events (incident response, settlement throughput). Wrapping them in a timelock would defeat their purpose.
+
+---
+
+## 3. Timelock architecture
+
+Two `TimelockController` instances (OpenZeppelin v5.6.1, vendored — see §6).
+
+### 3.1 Admin Timelock — 7 day delay
+
+**Purpose**: gates upgrades and any role-grant change.
+
+**Holds**:
+- Ownership of every UUPS contract (the `_authorizeUpgrade` authority)
+- `DEFAULT_ADMIN_ROLE` on the Operations Timelock (so role grants on it require the longer delay)
+
+**Roles**:
+- `PROPOSER_ROLE` → `ADMIN` (Fordefi x-of-y)
+- `CANCELLER_ROLE` → `GUARDIAN` (1-of-1) **and** `ADMIN`
+- `EXECUTOR_ROLE` → `address(0)` (anyone can execute after delay; this is a documented OZ option that decouples scheduling from execution)
+- `DEFAULT_ADMIN_ROLE` → the timelock itself (self-administered after deployer renounce)
+
+### 3.2 Operations Timelock — 24 hour delay
+
+**Purpose**: gates routine parameter changes (treasury config, fees, MultiFacetProxy selectors).
+
+**Roles**: same shape as Admin Timelock (proposer, canceller, executor) with the same Fordefi mappings, except `DEFAULT_ADMIN_ROLE` is held by the **Admin Timelock** (so role grants on this contract take 7 days, not 24h).
+
+### 3.3 Why two timelocks (not one)
+
+Single-timelock alternatives we rejected:
+- **One delay (7d) for everything**: makes routine fee changes painfully slow. Wrong tradeoff for the most-common ops.
+- **One delay (24h) for everything**: makes `_authorizeUpgrade` only 24h, which is insufficient user exit window for upgrade events.
+
+Two tiers (one slow for upgrades/role grants, one fast for parameter setters) addresses both edges of the tradeoff without proliferating tiers further. This is a standalone design decision derived from the gating function list in §4 — three or more tiers would not improve any cell in §4.
+
+### 3.4 Why we use `TimelockController` directly (no Governor wrapper)
+
+OZ provides `TimelockController` as a standalone contract. It can also be wrapped in a `Governor` for token-vote-driven proposals or in a custom selector-level access-control layer. KAM's gated functions (§4) are a small fixed set — 8 setters and 9 `_authorizeUpgrade` overrides. Wrapping the timelock in a more granular governance layer adds complexity (more contracts, more state, harder to reason about) for no benefit at this scale.
+
+We use `TimelockController` directly as the owner of UUPS contracts (via the existing Solady `Ownable` pattern) and add an `onlyOpsTimelock`-style check on setters. This is the canonical OZ usage pattern: the [OpenZeppelin governance README](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/governance/README.adoc) (MIT-licensed) explicitly states *"In a governance system, the {TimelockController} contract is in charge of introducing a delay between a proposal and its execution. It can be used with or without a {Governor}."*
+
+---
+
+## 4. Function-level gating
+
+### 4.1 Admin Timelock (7 day delay)
+
+| Contract | Function | Reason |
+|----------|----------|--------|
+| `kRegistry` | `_authorizeUpgrade` | UUPS upgrade — highest impact |
+| `kRemoteRegistry` | `_authorizeUpgrade` | UUPS upgrade |
+| `kMinter` | `_authorizeUpgrade` | UUPS upgrade |
+| `kAssetRouter` | `_authorizeUpgrade` | UUPS upgrade |
+| `kStakingVault` | `_authorizeUpgrade` | UUPS upgrade |
+| `VaultAdapter` | `_authorizeUpgrade` | UUPS upgrade |
+| `SmartAdapterAccount` | `_authorizeUpgrade` | Per-strategy but protocol-controlled — see open item §10.2 |
+| `kToken` (kToken0) | `_authorizeUpgrade` | UUPS upgrade |
+| `kTokenFactory` (kToken0) | `_authorizeUpgrade` | UUPS upgrade |
+| Operations Timelock | role grants on `PROPOSER_ROLE` / `CANCELLER_ROLE` | Role escalation must require the longer delay |
+
+### 4.2 Operations Timelock (24 hour delay)
+
+| Contract | Function | Reason |
+|----------|----------|--------|
+| `kRegistry` | `setTreasury` | Fee recipient change |
+| `kRegistry` | `setInsurance` | Insurance fund recipient change |
+| `kRegistry` | `setTreasuryBps` | Fee split |
+| `kRegistry` | `setInsuranceBps` | Fee split |
+| `kStakingVault` | `setManagementFee` | Vault fee |
+| `kStakingVault` | `setPerformanceFee` | Vault fee |
+| `kStakingVault` (MultiFacetProxy) | `addFunction` | Adds function selector |
+| `kStakingVault` (MultiFacetProxy) | `removeFunction` | Removes function selector |
+
+### 4.3 Instant (no timelock — role-gated only)
+
+| Function | Role | Why instant |
+|----------|------|-------------|
+| `setGlobalPause` | `EMERGENCY_ADMIN` | Incident response speed |
+| `setPaused` (per-contract) | `EMERGENCY_ADMIN` | Incident response speed |
+| `cancelProposal` (settlement, high-yield path) | `GUARDIAN` | Kill switch on bad yield proposal |
+| `cancel` on either Timelock | `GUARDIAN`, `ADMIN` | Cancel a bad queued op before it executes |
+| `rescueAssets`, `rescueETH` | `ADMIN` (still x-of-y) | Time-critical asset recovery; safety relies on x-of-y collusion barrier + `GUARDIAN` not being a co-signer |
+| All settlement / batch / mint / burn / claim ops | `MANAGER`, `RELAYER`, `INSTITUTION` | Operational throughput |
+
+---
+
+## 5. Migration plan
+
+### 5.1 `TimelockController` constructor
+
+The vendored OZ `TimelockController` (v5.6.1) constructor signature, as defined in `src/vendor/openzeppelin/governance/TimelockController.sol`:
+
+```solidity
+constructor(
+    uint256 minDelay,
+    address[] memory proposers,
+    address[] memory executors,
+    address admin
+)
+```
+
+`admin` is an *initial* admin used to bootstrap the role graph. After the role graph is configured, the deployer renounces `DEFAULT_ADMIN_ROLE` so the timelock is self-administered. This is the OZ-documented bootstrap pattern.
+
+### 5.2 Deploy → Grant → Renounce sequence
+
+Pseudocode for the migration script (Foundry-style):
+
+```solidity
+// Step 1: deploy timelocks
+adminTimelock = new TimelockController({
+    minDelay: 7 days,
+    proposers: [adminFordefi],
+    executors: [address(0)],          // anyone can execute after delay
+    admin: deployer                   // bootstrap admin
+});
+
+opsTimelock = new TimelockController({
+    minDelay: 24 hours,
+    proposers: [adminFordefi],
+    executors: [address(0)],
+    admin: deployer
+});
+
+// Step 2: grant CANCELLER to GUARDIAN on both
+adminTimelock.grantRole(CANCELLER_ROLE, guardianFordefi);
+opsTimelock.grantRole(CANCELLER_ROLE, guardianFordefi);
+
+// Step 3: grant DEFAULT_ADMIN_ROLE on Operations Timelock to Admin Timelock
+opsTimelock.grantRole(DEFAULT_ADMIN_ROLE, address(adminTimelock));
+
+// Step 4: deployer renounces DEFAULT_ADMIN_ROLE on each timelock
+//         (now Admin Timelock is self-administered, Operations Timelock is admin'd by Admin Timelock)
+adminTimelock.renounceRole(DEFAULT_ADMIN_ROLE, deployer);
+opsTimelock.renounceRole(DEFAULT_ADMIN_ROLE, deployer);
+
+// Step 5: transfer UUPS ownership to Admin Timelock (per contract)
+kRegistry.transferOwnership(address(adminTimelock));
+kMinter.transferOwnership(address(adminTimelock));
+// ...for each of the 9 UUPS contracts
+
+// Step 6: configure ops-timelock-gated setters
+//         (replace direct onlyOwner with onlyOpsTimelock modifier OR
+//          transfer the corresponding role to opsTimelock — see §5.4)
+```
+
+### 5.3 Per-UUPS-contract integration
+
+For each UUPS contract, change `_authorizeUpgrade` from:
+
+```solidity
+function _authorizeUpgrade(address) internal view override {
+    _checkOwner();
+}
+```
+
+to:
+
+```solidity
+function _authorizeUpgrade(address) internal view override {
+    require(msg.sender == address(adminTimelock), KCONTRACT_UPGRADE_NOT_TIMELOCK);
+}
+```
+
+The `adminTimelock` reference is read from `kRegistry` (`getAdminTimelock()`) so a single source of truth governs all 9 UUPS contracts. Same approach as the existing `_getKAssetRouter()` / `K_ASSET_ROUTER` pattern in this codebase.
+
+### 5.4 Per-setter integration (Operations Timelock)
+
+Two implementation options for setter gating:
+
+**Option A — `msg.sender` check** (simpler):
+```solidity
+function setTreasury(address _new) external {
+    require(msg.sender == address(opsTimelock), KREGISTRY_NOT_OPS_TIMELOCK);
+    // ... existing setter body
+}
+```
+
+**Option B — `onlyOpsTimelock` modifier** (more readable, same gas):
+```solidity
+modifier onlyOpsTimelock() {
+    require(msg.sender == address(opsTimelock), KREGISTRY_NOT_OPS_TIMELOCK);
+    _;
+}
+
+function setTreasury(address _new) external onlyOpsTimelock { ... }
+```
+
+**Recommendation: B.** Modifier-based for readability; consistent with existing `onlyOwner` / `_checkInstitution` patterns in this codebase.
+
+### 5.5 Cross-repo coordination
+
+Two repos are affected:
+- **kam** — 7 UUPS contracts
+- **kToken0** — 2 UUPS contracts (`kToken`, `kTokenFactory`)
+
+The timelock contracts live in **kam** (vendored under `src/vendor/openzeppelin/governance/`). kToken0 references the deployed timelock address via its registry pointer or constructor arg. Sequencing: kam timelocks deployed first, addresses recorded in deployment artifacts, then kToken0's UUPS contracts upgraded to point at the kam-deployed timelock.
+
+### 5.6 Rollback
+
+**No rollback.** Once `transferOwnership(timelock)` is executed, the previous owner loses all authority. Only the timelock can undo it — via a timelock-gated proposal that itself takes the same delay.
+
+Mitigation:
+1. **Testnet rehearsal**: full deploy → grant → renounce → upgrade → fee-change cycle on Sepolia (or local fork) before mainnet.
+2. **Foundry simulation script**: the migration is a Foundry script committed to the repo, dry-run via `forge script --rpc-url <fork> --sender <deployer>` and reviewed alongside this spec.
+3. **Per-step pause-and-verify**: after each `transferOwnership`, the script reads the new owner on-chain and aborts the entire migration if any step doesn't match expectations.
+
+---
+
+## 6. Vendored contract
+
+OpenZeppelin Contracts **v5.6.1** (released 2026-02-27) is vendored under `src/vendor/openzeppelin/`. Same convention as the existing `src/vendor/openzeppelin/Proxy.sol`. **No modifications** to OZ source — files are copied verbatim with original SPDX (`MIT`), version pragma, and OZ header comments preserved.
+
+13 files vendored:
+
+```
+src/vendor/openzeppelin/
+├── governance/
+│   └── TimelockController.sol
+├── access/
+│   ├── AccessControl.sol
+│   └── IAccessControl.sol
+├── token/
+│   ├── ERC721/
+│   │   ├── IERC721Receiver.sol
+│   │   └── utils/ERC721Holder.sol
+│   └── ERC1155/
+│       ├── IERC1155Receiver.sol
+│       └── utils/ERC1155Holder.sol
+└── utils/
+    ├── Address.sol
+    ├── Context.sol
+    ├── Errors.sol
+    ├── LowLevelCall.sol
+    └── introspection/
+        ├── ERC165.sol
+        └── IERC165.sol
+```
+
+The `ERC721Holder` and `ERC1155Holder` inheritance is dead weight for our use case (we don't expect the timelock to receive NFTs) but keeping the vendor copy unmodified avoids future divergence cost when bumping OZ versions.
+
+**Licensing note**: OZ Contracts is MIT — permissive, compatible with proprietary use. The MIT license requires preservation of the copyright notice (which we do via the unchanged headers). KAM's own code remains `UNLICENSED` and is unaffected by the vendored MIT files.
+
+---
+
+## 7. How to operate the timelock
+
+The OZ `TimelockController` lifecycle is `Unset → Pending → Pending+Ready → Done`, managed by `schedule()`, `execute()`, and `cancel()`. These are the OZ-documented public API. Below is the concrete usage for KAM's two timelocks.
+
+### 7.1 Schedule a single op
+
+```solidity
+// Encode the call we want to defer
+bytes memory data = abi.encodeCall(IkRegistry.setTreasury, (newTreasury));
+
+// PROPOSER (ADMIN x-of-y Fordefi) calls schedule()
+opsTimelock.schedule({
+    target:      address(kRegistry),
+    value:       0,                     // no ETH
+    data:        data,
+    predecessor: bytes32(0),            // no dependency on prior op
+    salt:        keccak256("set-treasury-2026-05-15"),  // uniqueness
+    delay:       opsTimelock.getMinDelay()              // = 24 hours
+});
+```
+
+After this call, the op is `Pending`. Anyone can read `opsTimelock.isOperationPending(id)` and the on-chain `CallScheduled` event records all params.
+
+### 7.2 Execute a scheduled op
+
+After the delay elapses:
+
+```solidity
+// EXECUTOR_ROLE is open — anyone can call this.
+opsTimelock.execute({
+    target:      address(kRegistry),
+    value:       0,
+    data:        data,
+    predecessor: bytes32(0),
+    salt:        keccak256("set-treasury-2026-05-15")
+});
+```
+
+The same `data` as scheduled. Mismatch → revert. Op state becomes `Done`.
+
+For batch execution, the migration script should reconstruct the original schedule params from the on-chain `CallScheduled` event log (event signature: `CallScheduled(bytes32 indexed id, uint256 indexed index, address target, uint256 value, bytes data, bytes32 predecessor, uint256 delay)`), then call `executeBatch(targets, values, datas, predecessor, salt)`. This avoids needing to remember salts off-chain.
+
+### 7.3 Cancel a queued op
+
+Before the delay passes:
+
+```solidity
+// GUARDIAN (1-of-1 Fordefi) or ADMIN can call cancel()
+bytes32 id = opsTimelock.hashOperation(target, value, data, predecessor, salt);
+opsTimelock.cancel(id);
+```
+
+Op state goes back to `Unset`. The proposer must re-schedule from scratch (with fresh salt) to retry.
+
+### 7.4 Batch operations (multiple targets in one go)
+
+`scheduleBatch` / `executeBatch` accept arrays. Useful for atomically rotating treasury + insurance + bps in one delay window.
+
+---
+
+## 8. How to update a function's delay (post-deployment)
+
+Each timelock has a single `minDelay`. Changing it is itself a timelock-gated operation through the same timelock — `updateDelay` on `TimelockController` is restricted to `address(this)` per the OZ source.
+
+### 8.1 The procedure (ops-timelock 24h example)
+
+To change the Operations Timelock delay from 24h to 12h:
+
+```solidity
+// Step 1: encode the updateDelay call (target = the timelock itself)
+bytes memory data = abi.encodeCall(TimelockController.updateDelay, (12 hours));
+
+// Step 2: PROPOSER (ADMIN) schedules it on the SAME timelock
+opsTimelock.schedule({
+    target:      address(opsTimelock),
+    value:       0,
+    data:        data,
+    predecessor: bytes32(0),
+    salt:        keccak256("ops-delay-update-24h-to-12h"),
+    delay:       opsTimelock.getMinDelay()   // current = 24h
+});
+
+// Step 3: wait 24 hours. During this window, GUARDIAN can cancel.
+
+// Step 4: anyone calls execute()
+opsTimelock.execute(address(opsTimelock), 0, data, bytes32(0), keccak256("ops-delay-update-24h-to-12h"));
+
+// New minDelay (12h) applies to operations scheduled AFTER this point.
+// Operations already in flight retain their original 24h delay.
+```
+
+### 8.2 Adjustability boundaries
+
+OZ `TimelockController` allows any non-negative `minDelay`. Per-protocol policy, we recommend (not enforced in code):
+- **Operations Timelock**: never less than **6 hours**, never more than **3 days**
+- **Admin Timelock**: never less than **3 days**, never more than **14 days**
+
+Going below the floor sacrifices user-exit window; going above hampers operational responsiveness. The boundaries above are documented as an operating convention; enforcement would require a custom timelock or off-chain process review.
+
+### 8.3 Per-function delay differentiation
+
+The two-timelock split gives us two delay tiers (7d / 24h). If a future change requires a *third* delay (e.g. a 48h tier for a single specific function), the implementation path is to:
+1. Deploy a third `TimelockController` with the new delay
+2. Move the relevant function's gating from one timelock to the new one (via a timelock-gated proposal on the *current* gating timelock)
+
+This is intentionally heavy — each delay tier costs a deployment and a migration — to discourage proliferation. Two tiers should suffice indefinitely.
+
+---
+
+## 9. Build roadmap
+
+Phase 6 implementation lands in this order. Each numbered item is one or more atomic commits, all on `post-audit-phase-6`. Each commit must compile clean and not break existing tests.
+
+| # | Task | Outputs |
+|---|------|---------|
+| 1 | ✅ Vendor OZ TimelockController v5.6.1 + dependencies | `src/vendor/openzeppelin/{governance,access,token,utils}/...` (13 files) |
+| 2 | ✅ Spec doc | `docs/timelock-and-governance-spec.md` (this file) |
+| 3 | Add `adminTimelock` and `opsTimelock` references on kRegistry | `kRegistry.sol`, `IRegistry.sol`, getter functions, registry init expanded |
+| 4 | Add error codes for timelock gating | `src/errors/Errors.sol` (e.g. `KCONTRACT_UPGRADE_NOT_TIMELOCK`, `KREGISTRY_NOT_OPS_TIMELOCK`, etc.) |
+| 5 | Wire `_authorizeUpgrade` for each UUPS contract | 9 contract-level edits (kam: 7, kToken0: 2) |
+| 6 | Add `onlyOpsTimelock` modifier and apply to gated setters | `kRegistry.setTreasury / setInsurance / setTreasuryBps / setInsuranceBps`; `kStakingVault.setManagementFee / setPerformanceFee`; `MultiFacetProxy.addFunction / removeFunction` |
+| 7 | Per-timelock unit tests | `test/unit/AdminTimelock.t.sol`, `test/unit/OperationsTimelock.t.sol` |
+| 8 | Per-gated-function integration tests | One test file per modified contract, `_viaTimelock_*` + `_directly_reverts` patterns |
+| 9 | Emergency-exemption tests | `test/unit/EmergencyExemptions.t.sol` covering pause / cancel / rescue concurrency with queued timelock ops |
+| 10 | Migration Foundry script | `script/migrations/06_TimelockMigration.s.sol`, dry-runnable on a fork |
+| 11 | Migration tests on a fork | `test/integration/TimelockMigration.t.sol` validating full deploy → grant → renounce → upgrade cycle |
+| 12 | Update `docs/architecture.md` | New § on timelock window + user exit paths |
+| 13 | kToken0 mirror PR | Wire `_authorizeUpgrade` on kToken/kTokenFactory in the kToken0 repo, referencing the kam-deployed timelock address |
+
+Post-merge:
+14. Testnet deployment rehearsal (Sepolia) of full migration
+15. External audit (delta review against Phase 1-7)
+16. Mainnet migration
+
+### 9.1 Estimated commits and review surface
+
+- ~3 small commits for tasks 3-4 (foundation)
+- ~9 contract-level commits for tasks 5-6 (one per UUPS / setter group)
+- ~5 test-suite commits for tasks 7-9
+- ~2 commits for task 10-11 (migration script + integration test)
+- ~1 doc commit for task 12
+
+Total: ~20 commits in the kam PR + ~3 commits in a kToken0 PR. Reviewable in 2-3 sittings.
+
+---
+
+## 10. Open items (settle before implementation begins past task #2)
+
+### 10.1 ADMIN multisig configuration
+Recommended: **3-of-5** Fordefi MPC. Final value decided by team and committed alongside deployment script.
+
+### 10.2 SmartAdapterAccount upgrade authority
+`SmartAdapterAccount` is deployed per-strategy but the protocol controls strategy registration. Two options:
+- **(a)** Admin Timelock (treats it as protocol infrastructure)
+- **(b)** Per-strategy manager key (treats it like a user wallet)
+
+**Recommendation: (a) — Admin Timelock.** Strategies are protocol-managed; allowing per-strategy unilateral upgrades creates a path for a strategy manager to brick or rug their adapter.
+
+### 10.3 OpenZeppelin Contracts version — RESOLVED
+Pinned to **v5.6.1** (released 2026-02-27). 2+ months in the wild, no post-release advisories on the governance module as of vendoring date. See §6.
+
+### 10.4 MultiFacetProxy `addFunction` / `removeFunction` granularity
+Currently spec gates the entire `addFunction` / `removeFunction` selectors via Operations Timelock. Open question: should certain pre-approved selectors (e.g. internal helper additions) bypass the timelock? **Recommendation: no — keep the simple "all selector changes go through 24h" rule.** Premature optimization to relax is rejected.
+
+### 10.5 Initial Timelock proposers — single ADMIN multisig only?
+Currently spec says only the ADMIN x-of-y multisig is `PROPOSER_ROLE`. Should there be a backup proposer (e.g. a second multisig held by counsel)? **Recommendation: no.** A single proposer keeps the role model simple. If the ADMIN multisig is compromised, recovery requires a chain-state hard fork anyway, and a backup proposer in the same custody system doesn't materially help.
+
+---
+
+## 11. References
+
+This specification cites only:
+- **OpenZeppelin Contracts v5.6.1** (MIT) — vendored under `src/vendor/openzeppelin/`. Source code, API, and the governance README are MIT-licensed and freely citable.
+- **KAM internal documents** — predecessor and companion docs in this same `docs/` directory.
+- **Fordefi documentation** — vendor docs for the MPC custody product KAM uses.
+
+| Source | Relevance |
+|--------|-----------|
+| [`docs/post-audit-improvement-plan.md`](post-audit-improvement-plan.md) Phase 6 | Original audit recommendation |
+| [`docs/security-design-roles-spec.md`](security-design-roles-spec.md) | Existing role spec (this doc adds the timelock layer on top) |
+| [OpenZeppelin TimelockController docs](https://docs.openzeppelin.com/contracts/5.x/api/governance#TimelockController) | API reference for the vendored contract |
+| [OpenZeppelin governance README](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/governance/README.adoc) | Canonical statement that `TimelockController` can be used with or without a Governor |
+| [OpenZeppelin AccessControl docs](https://docs.openzeppelin.com/contracts/5.x/api/access#AccessControl) | API reference for the role-management primitives `TimelockController` inherits |
+| [Fordefi institutional MPC](https://fordefi.com/) | Custody product used for all role wallets |
+
+We do **not** derive code or patterns from any other licensed protocol's source code. Architectural decisions in this document originate from the Trail of Bits audit findings, OpenZeppelin's published API and recommended practices, and KAM-specific requirements.
+
+---
+
+## 12. Sign-off
+
+This spec must be acknowledged by both engineering leads before Phase 6 implementation past task #2 begins. Implementation tracks against this contract; deviations require a follow-up revision PR before merging.
+
+| Reviewer | Status | Date |
+|----------|--------|------|
+| Engineering Lead 1 | ☐ pending | |
+| Engineering Lead 2 | ☐ pending | |

--- a/src/vendor/openzeppelin/access/AccessControl.sol
+++ b/src/vendor/openzeppelin/access/AccessControl.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.6.0) (access/AccessControl.sol)
+
+pragma solidity ^0.8.20;
+
+import {IAccessControl} from "./IAccessControl.sol";
+import {Context} from "../utils/Context.sol";
+import {ERC165} from "../utils/introspection/ERC165.sol";
+
+/**
+ * @dev Contract module that allows children to implement role-based access
+ * control mechanisms. This is a lightweight version that doesn't allow enumerating role
+ * members except through off-chain means by accessing the contract event logs. Some
+ * applications may benefit from on-chain enumerability, for those cases see
+ * {AccessControlEnumerable}.
+ *
+ * Roles are referred to by their `bytes32` identifier. These should be exposed
+ * in the external API and be unique. The best way to achieve this is by
+ * using `public constant` hash digests:
+ *
+ * ```solidity
+ * bytes32 public constant MY_ROLE = keccak256("MY_ROLE");
+ * ```
+ *
+ * Roles can be used to represent a set of permissions. To restrict access to a
+ * function call, use {hasRole}:
+ *
+ * ```solidity
+ * function foo() public {
+ *     require(hasRole(MY_ROLE, msg.sender));
+ *     ...
+ * }
+ * ```
+ *
+ * Roles can be granted and revoked dynamically via the {grantRole} and
+ * {revokeRole} functions. Each role has an associated admin role, and only
+ * accounts that have a role's admin role can call {grantRole} and {revokeRole}.
+ *
+ * By default, the admin role for all roles is `DEFAULT_ADMIN_ROLE`, which means
+ * that only accounts with this role will be able to grant or revoke other
+ * roles. More complex role relationships can be created by using
+ * {_setRoleAdmin}.
+ *
+ * WARNING: The `DEFAULT_ADMIN_ROLE` is also its own admin: it has permission to
+ * grant and revoke this role. Extra precautions should be taken to secure
+ * accounts that have been granted it. We recommend using {AccessControlDefaultAdminRules}
+ * to enforce additional security measures for this role.
+ */
+abstract contract AccessControl is Context, IAccessControl, ERC165 {
+    struct RoleData {
+        mapping(address account => bool) hasRole;
+        bytes32 adminRole;
+    }
+
+    mapping(bytes32 role => RoleData) private _roles;
+
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    /**
+     * @dev Modifier that checks that an account has a specific role. Reverts
+     * with an {AccessControlUnauthorizedAccount} error including the required role.
+     */
+    modifier onlyRole(bytes32 role) {
+        _checkRole(role);
+        _;
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IAccessControl).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev Returns `true` if `account` has been granted `role`.
+     */
+    function hasRole(bytes32 role, address account) public view virtual returns (bool) {
+        return _roles[role].hasRole[account];
+    }
+
+    /**
+     * @dev Reverts with an {AccessControlUnauthorizedAccount} error if `_msgSender()`
+     * is missing `role`. Overriding this function changes the behavior of the {onlyRole} modifier.
+     */
+    function _checkRole(bytes32 role) internal view virtual {
+        _checkRole(role, _msgSender());
+    }
+
+    /**
+     * @dev Reverts with an {AccessControlUnauthorizedAccount} error if `account`
+     * is missing `role`.
+     */
+    function _checkRole(bytes32 role, address account) internal view virtual {
+        if (!hasRole(role, account)) {
+            revert AccessControlUnauthorizedAccount(account, role);
+        }
+    }
+
+    /**
+     * @dev Returns the admin role that controls `role`. See {grantRole} and
+     * {revokeRole}.
+     *
+     * To change a role's admin, use {_setRoleAdmin}.
+     */
+    function getRoleAdmin(bytes32 role) public view virtual returns (bytes32) {
+        return _roles[role].adminRole;
+    }
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * If `account` had not been already granted `role`, emits a {RoleGranted}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     *
+     * May emit a {RoleGranted} event.
+     */
+    function grantRole(bytes32 role, address account) public virtual onlyRole(getRoleAdmin(role)) {
+        _grantRole(role, account);
+    }
+
+    /**
+     * @dev Revokes `role` from `account`.
+     *
+     * If `account` had been granted `role`, emits a {RoleRevoked} event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     *
+     * May emit a {RoleRevoked} event.
+     */
+    function revokeRole(bytes32 role, address account) public virtual onlyRole(getRoleAdmin(role)) {
+        _revokeRole(role, account);
+    }
+
+    /**
+     * @dev Revokes `role` from the calling account.
+     *
+     * Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to lose their privileges
+     * if they are compromised (such as when a trusted device is misplaced).
+     *
+     * If the calling account had been revoked `role`, emits a {RoleRevoked}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must be `callerConfirmation`.
+     *
+     * May emit a {RoleRevoked} event.
+     */
+    function renounceRole(bytes32 role, address callerConfirmation) public virtual {
+        if (callerConfirmation != _msgSender()) {
+            revert AccessControlBadConfirmation();
+        }
+
+        _revokeRole(role, callerConfirmation);
+    }
+
+    /**
+     * @dev Sets `adminRole` as ``role``'s admin role.
+     *
+     * Emits a {RoleAdminChanged} event.
+     */
+    function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
+        bytes32 previousAdminRole = getRoleAdmin(role);
+        _roles[role].adminRole = adminRole;
+        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+    }
+
+    /**
+     * @dev Attempts to grant `role` to `account` and returns a boolean indicating if `role` was granted.
+     *
+     * Internal function without access restriction.
+     *
+     * May emit a {RoleGranted} event.
+     */
+    function _grantRole(bytes32 role, address account) internal virtual returns (bool) {
+        if (!hasRole(role, account)) {
+            _roles[role].hasRole[account] = true;
+            emit RoleGranted(role, account, _msgSender());
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @dev Attempts to revoke `role` from `account` and returns a boolean indicating if `role` was revoked.
+     *
+     * Internal function without access restriction.
+     *
+     * May emit a {RoleRevoked} event.
+     */
+    function _revokeRole(bytes32 role, address account) internal virtual returns (bool) {
+        if (hasRole(role, account)) {
+            _roles[role].hasRole[account] = false;
+            emit RoleRevoked(role, account, _msgSender());
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/vendor/openzeppelin/access/IAccessControl.sol
+++ b/src/vendor/openzeppelin/access/IAccessControl.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.4.0) (access/IAccessControl.sol)
+
+pragma solidity >=0.8.4;
+
+/**
+ * @dev External interface of AccessControl declared to support ERC-165 detection.
+ */
+interface IAccessControl {
+    /**
+     * @dev The `account` is missing a role.
+     */
+    error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
+
+    /**
+     * @dev The caller of a function is not the expected one.
+     *
+     * NOTE: Don't confuse with {AccessControlUnauthorizedAccount}.
+     */
+    error AccessControlBadConfirmation();
+
+    /**
+     * @dev Emitted when `newAdminRole` is set as ``role``'s admin role, replacing `previousAdminRole`
+     *
+     * `DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite
+     * {RoleAdminChanged} not being emitted to signal this.
+     */
+    event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+
+    /**
+     * @dev Emitted when `account` is granted `role`.
+     *
+     * `sender` is the account that originated the contract call. This account bears the admin role (for the granted role).
+     * Expected in cases where the role was granted using the internal {AccessControl-_grantRole}.
+     */
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /**
+     * @dev Emitted when `account` is revoked `role`.
+     *
+     * `sender` is the account that originated the contract call:
+     *   - if using `revokeRole`, it is the admin role bearer
+     *   - if using `renounceRole`, it is the role bearer (i.e. `account`)
+     */
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /**
+     * @dev Returns `true` if `account` has been granted `role`.
+     */
+    function hasRole(bytes32 role, address account) external view returns (bool);
+
+    /**
+     * @dev Returns the admin role that controls `role`. See {grantRole} and
+     * {revokeRole}.
+     *
+     * To change a role's admin, use {AccessControl-_setRoleAdmin}.
+     */
+    function getRoleAdmin(bytes32 role) external view returns (bytes32);
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * If `account` had not been already granted `role`, emits a {RoleGranted}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     */
+    function grantRole(bytes32 role, address account) external;
+
+    /**
+     * @dev Revokes `role` from `account`.
+     *
+     * If `account` had been granted `role`, emits a {RoleRevoked} event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     */
+    function revokeRole(bytes32 role, address account) external;
+
+    /**
+     * @dev Revokes `role` from the calling account.
+     *
+     * Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to lose their privileges
+     * if they are compromised (such as when a trusted device is misplaced).
+     *
+     * If the calling account had been granted `role`, emits a {RoleRevoked}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must be `callerConfirmation`.
+     */
+    function renounceRole(bytes32 role, address callerConfirmation) external;
+}

--- a/src/vendor/openzeppelin/governance/TimelockController.sol
+++ b/src/vendor/openzeppelin/governance/TimelockController.sol
@@ -1,0 +1,470 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.6.0) (governance/TimelockController.sol)
+
+pragma solidity ^0.8.20;
+
+import {AccessControl} from "../access/AccessControl.sol";
+import {ERC721Holder} from "../token/ERC721/utils/ERC721Holder.sol";
+import {ERC1155Holder} from "../token/ERC1155/utils/ERC1155Holder.sol";
+import {Address} from "../utils/Address.sol";
+
+/**
+ * @dev Contract module which acts as a timelocked controller. When set as the
+ * owner of an `Ownable` smart contract, it enforces a timelock on all
+ * `onlyOwner` maintenance operations. This gives time for users of the
+ * controlled contract to exit before a potentially dangerous maintenance
+ * operation is applied.
+ *
+ * By default, this contract is self administered, meaning administration tasks
+ * have to go through the timelock process. The proposer (resp executor) role
+ * is in charge of proposing (resp executing) operations. A common use case is
+ * to position this {TimelockController} as the owner of a smart contract, with
+ * a multisig or a DAO as the sole proposer.
+ */
+contract TimelockController is AccessControl, ERC721Holder, ERC1155Holder {
+    bytes32 public constant PROPOSER_ROLE = keccak256("PROPOSER_ROLE");
+    bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+    bytes32 public constant CANCELLER_ROLE = keccak256("CANCELLER_ROLE");
+    uint256 internal constant DONE_TIMESTAMP = uint256(1);
+
+    mapping(bytes32 id => uint256) private _timestamps;
+    uint256 private _minDelay;
+
+    enum OperationState {
+        Unset,
+        Waiting,
+        Ready,
+        Done
+    }
+
+    /**
+     * @dev Mismatch between the parameters length for an operation call.
+     */
+    error TimelockInvalidOperationLength(uint256 targets, uint256 payloads, uint256 values);
+
+    /**
+     * @dev The schedule operation doesn't meet the minimum delay.
+     */
+    error TimelockInsufficientDelay(uint256 delay, uint256 minDelay);
+
+    /**
+     * @dev The current state of an operation is not as required.
+     * The `expectedStates` is a bitmap with the bits enabled for each OperationState enum position
+     * counting from right to left.
+     *
+     * See {_encodeStateBitmap}.
+     */
+    error TimelockUnexpectedOperationState(bytes32 operationId, bytes32 expectedStates);
+
+    /**
+     * @dev The predecessor to an operation not yet done.
+     */
+    error TimelockUnexecutedPredecessor(bytes32 predecessorId);
+
+    /**
+     * @dev The caller account is not authorized.
+     */
+    error TimelockUnauthorizedCaller(address caller);
+
+    /**
+     * @dev Emitted when a call is scheduled as part of operation `id`.
+     */
+    event CallScheduled(
+        bytes32 indexed id,
+        uint256 indexed index,
+        address target,
+        uint256 value,
+        bytes data,
+        bytes32 predecessor,
+        uint256 delay
+    );
+
+    /**
+     * @dev Emitted when a call is performed as part of operation `id`.
+     */
+    event CallExecuted(bytes32 indexed id, uint256 indexed index, address target, uint256 value, bytes data);
+
+    /**
+     * @dev Emitted when new proposal is scheduled with non-zero salt.
+     */
+    event CallSalt(bytes32 indexed id, bytes32 salt);
+
+    /**
+     * @dev Emitted when operation `id` is cancelled.
+     */
+    event Cancelled(bytes32 indexed id);
+
+    /**
+     * @dev Emitted when the minimum delay for future operations is modified.
+     */
+    event MinDelayChange(uint256 oldDuration, uint256 newDuration);
+
+    /**
+     * @dev Initializes the contract with the following parameters:
+     *
+     * - `minDelay`: initial minimum delay in seconds for operations
+     * - `proposers`: accounts to be granted proposer and canceller roles
+     * - `executors`: accounts to be granted executor role
+     * - `admin`: optional account to be granted admin role; disable with zero address
+     *
+     * IMPORTANT: The optional admin can aid with initial configuration of roles after deployment
+     * without being subject to delay, but this role should be subsequently renounced in favor of
+     * administration through timelocked proposals. Previous versions of this contract would assign
+     * this admin to the deployer automatically and should be renounced as well.
+     */
+    constructor(uint256 minDelay, address[] memory proposers, address[] memory executors, address admin) {
+        // self administration
+        _grantRole(DEFAULT_ADMIN_ROLE, address(this));
+
+        // optional admin
+        if (admin != address(0)) {
+            _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        }
+
+        // register proposers and cancellers
+        for (uint256 i = 0; i < proposers.length; ++i) {
+            _grantRole(PROPOSER_ROLE, proposers[i]);
+            _grantRole(CANCELLER_ROLE, proposers[i]);
+        }
+
+        // register executors
+        for (uint256 i = 0; i < executors.length; ++i) {
+            _grantRole(EXECUTOR_ROLE, executors[i]);
+        }
+
+        _minDelay = minDelay;
+        emit MinDelayChange(0, minDelay);
+    }
+
+    /**
+     * @dev Modifier to make a function callable only by a certain role. In
+     * addition to checking the sender's role, `address(0)` 's role is also
+     * considered. Granting a role to `address(0)` is equivalent to enabling
+     * this role for everyone.
+     */
+    modifier onlyRoleOrOpenRole(bytes32 role) {
+        if (!hasRole(role, address(0))) {
+            _checkRole(role, _msgSender());
+        }
+        _;
+    }
+
+    /**
+     * @dev Contract might receive/hold ETH as part of the maintenance process.
+     */
+    receive() external payable virtual {}
+
+    /// @inheritdoc AccessControl
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(AccessControl, ERC1155Holder) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev Returns whether an id corresponds to a registered operation. This
+     * includes both Waiting, Ready, and Done operations.
+     */
+    function isOperation(bytes32 id) public view returns (bool) {
+        return getOperationState(id) != OperationState.Unset;
+    }
+
+    /**
+     * @dev Returns whether an operation is pending or not. Note that a "pending" operation may also be "ready".
+     */
+    function isOperationPending(bytes32 id) public view returns (bool) {
+        OperationState state = getOperationState(id);
+        return state == OperationState.Waiting || state == OperationState.Ready;
+    }
+
+    /**
+     * @dev Returns whether an operation is ready for execution. Note that a "ready" operation is also "pending".
+     */
+    function isOperationReady(bytes32 id) public view returns (bool) {
+        return getOperationState(id) == OperationState.Ready;
+    }
+
+    /**
+     * @dev Returns whether an operation is done or not.
+     */
+    function isOperationDone(bytes32 id) public view returns (bool) {
+        return getOperationState(id) == OperationState.Done;
+    }
+
+    /**
+     * @dev Returns the timestamp at which an operation becomes ready (0 for
+     * unset operations, 1 for done operations).
+     */
+    function getTimestamp(bytes32 id) public view virtual returns (uint256) {
+        return _timestamps[id];
+    }
+
+    /**
+     * @dev Returns operation state.
+     */
+    function getOperationState(bytes32 id) public view virtual returns (OperationState) {
+        uint256 timestamp = getTimestamp(id);
+        if (timestamp == 0) {
+            return OperationState.Unset;
+        } else if (timestamp == DONE_TIMESTAMP) {
+            return OperationState.Done;
+        } else if (timestamp > block.timestamp) {
+            return OperationState.Waiting;
+        } else {
+            return OperationState.Ready;
+        }
+    }
+
+    /**
+     * @dev Returns the minimum delay in seconds for an operation to become valid.
+     *
+     * This value can be changed by executing an operation that calls `updateDelay`.
+     */
+    function getMinDelay() public view virtual returns (uint256) {
+        return _minDelay;
+    }
+
+    /**
+     * @dev Returns the identifier of an operation containing a single
+     * transaction.
+     */
+    function hashOperation(
+        address target,
+        uint256 value,
+        bytes calldata data,
+        bytes32 predecessor,
+        bytes32 salt
+    ) public pure virtual returns (bytes32) {
+        return keccak256(abi.encode(target, value, data, predecessor, salt));
+    }
+
+    /**
+     * @dev Returns the identifier of an operation containing a batch of
+     * transactions.
+     */
+    function hashOperationBatch(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata payloads,
+        bytes32 predecessor,
+        bytes32 salt
+    ) public pure virtual returns (bytes32) {
+        return keccak256(abi.encode(targets, values, payloads, predecessor, salt));
+    }
+
+    /**
+     * @dev Schedule an operation containing a single transaction.
+     *
+     * Emits {CallSalt} if salt is nonzero, and {CallScheduled}.
+     *
+     * Requirements:
+     *
+     * - the caller must have the 'proposer' role.
+     */
+    function schedule(
+        address target,
+        uint256 value,
+        bytes calldata data,
+        bytes32 predecessor,
+        bytes32 salt,
+        uint256 delay
+    ) public virtual onlyRole(PROPOSER_ROLE) {
+        bytes32 id = hashOperation(target, value, data, predecessor, salt);
+        _schedule(id, delay);
+        emit CallScheduled(id, 0, target, value, data, predecessor, delay);
+        if (salt != bytes32(0)) {
+            emit CallSalt(id, salt);
+        }
+    }
+
+    /**
+     * @dev Schedule an operation containing a batch of transactions.
+     *
+     * Emits {CallSalt} if salt is nonzero, and one {CallScheduled} event per transaction in the batch.
+     *
+     * Requirements:
+     *
+     * - the caller must have the 'proposer' role.
+     */
+    function scheduleBatch(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata payloads,
+        bytes32 predecessor,
+        bytes32 salt,
+        uint256 delay
+    ) public virtual onlyRole(PROPOSER_ROLE) {
+        if (targets.length != values.length || targets.length != payloads.length) {
+            revert TimelockInvalidOperationLength(targets.length, payloads.length, values.length);
+        }
+
+        bytes32 id = hashOperationBatch(targets, values, payloads, predecessor, salt);
+        _schedule(id, delay);
+        for (uint256 i = 0; i < targets.length; ++i) {
+            emit CallScheduled(id, i, targets[i], values[i], payloads[i], predecessor, delay);
+        }
+        if (salt != bytes32(0)) {
+            emit CallSalt(id, salt);
+        }
+    }
+
+    /**
+     * @dev Schedule an operation that is to become valid after a given delay.
+     */
+    function _schedule(bytes32 id, uint256 delay) private {
+        if (isOperation(id)) {
+            revert TimelockUnexpectedOperationState(id, _encodeStateBitmap(OperationState.Unset));
+        }
+        uint256 minDelay = getMinDelay();
+        if (delay < minDelay) {
+            revert TimelockInsufficientDelay(delay, minDelay);
+        }
+        _timestamps[id] = block.timestamp + delay;
+    }
+
+    /**
+     * @dev Cancel an operation.
+     *
+     * Requirements:
+     *
+     * - the caller must have the 'canceller' role.
+     */
+    function cancel(bytes32 id) public virtual onlyRole(CANCELLER_ROLE) {
+        if (!isOperationPending(id)) {
+            revert TimelockUnexpectedOperationState(
+                id,
+                _encodeStateBitmap(OperationState.Waiting) | _encodeStateBitmap(OperationState.Ready)
+            );
+        }
+        delete _timestamps[id];
+
+        emit Cancelled(id);
+    }
+
+    /**
+     * @dev Execute a ready operation containing a single transaction.
+     *
+     * Emits a {CallExecuted} event.
+     *
+     * Requirements:
+     *
+     * - the caller must have the 'executor' role.
+     */
+    // This function can reenter, but it doesn't pose a risk because _afterCall checks that the proposal is pending,
+    // thus any modifications to the operation during reentrancy should be caught.
+    // slither-disable-next-line reentrancy-eth
+    function execute(
+        address target,
+        uint256 value,
+        bytes calldata payload,
+        bytes32 predecessor,
+        bytes32 salt
+    ) public payable virtual onlyRoleOrOpenRole(EXECUTOR_ROLE) {
+        bytes32 id = hashOperation(target, value, payload, predecessor, salt);
+
+        _beforeCall(id, predecessor);
+        _execute(target, value, payload);
+        emit CallExecuted(id, 0, target, value, payload);
+        _afterCall(id);
+    }
+
+    /**
+     * @dev Execute a ready operation containing a batch of transactions.
+     *
+     * Emits one {CallExecuted} event per transaction in the batch.
+     *
+     * Requirements:
+     *
+     * - the caller must have the 'executor' role.
+     */
+    // This function can reenter, but it doesn't pose a risk because _afterCall checks that the proposal is pending,
+    // thus any modifications to the operation during reentrancy should be caught.
+    // slither-disable-next-line reentrancy-eth
+    function executeBatch(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata payloads,
+        bytes32 predecessor,
+        bytes32 salt
+    ) public payable virtual onlyRoleOrOpenRole(EXECUTOR_ROLE) {
+        if (targets.length != values.length || targets.length != payloads.length) {
+            revert TimelockInvalidOperationLength(targets.length, payloads.length, values.length);
+        }
+
+        bytes32 id = hashOperationBatch(targets, values, payloads, predecessor, salt);
+
+        _beforeCall(id, predecessor);
+        for (uint256 i = 0; i < targets.length; ++i) {
+            address target = targets[i];
+            uint256 value = values[i];
+            bytes calldata payload = payloads[i];
+            _execute(target, value, payload);
+            emit CallExecuted(id, i, target, value, payload);
+        }
+        _afterCall(id);
+    }
+
+    /**
+     * @dev Execute an operation's call.
+     */
+    function _execute(address target, uint256 value, bytes calldata data) internal virtual {
+        (bool success, bytes memory returndata) = target.call{value: value}(data);
+        Address.verifyCallResult(success, returndata);
+    }
+
+    /**
+     * @dev Checks before execution of an operation's calls.
+     */
+    function _beforeCall(bytes32 id, bytes32 predecessor) private view {
+        if (!isOperationReady(id)) {
+            revert TimelockUnexpectedOperationState(id, _encodeStateBitmap(OperationState.Ready));
+        }
+        if (predecessor != bytes32(0) && !isOperationDone(predecessor)) {
+            revert TimelockUnexecutedPredecessor(predecessor);
+        }
+    }
+
+    /**
+     * @dev Checks after execution of an operation's calls.
+     */
+    function _afterCall(bytes32 id) private {
+        if (!isOperationReady(id)) {
+            revert TimelockUnexpectedOperationState(id, _encodeStateBitmap(OperationState.Ready));
+        }
+        _timestamps[id] = DONE_TIMESTAMP;
+    }
+
+    /**
+     * @dev Changes the minimum timelock duration for future operations.
+     *
+     * Emits a {MinDelayChange} event.
+     *
+     * Requirements:
+     *
+     * - the caller must be the timelock itself. This can only be achieved by scheduling and later executing
+     * an operation where the timelock is the target and the data is the ABI-encoded call to this function.
+     */
+    function updateDelay(uint256 newDelay) public virtual {
+        address sender = _msgSender();
+        if (sender != address(this)) {
+            revert TimelockUnauthorizedCaller(sender);
+        }
+        emit MinDelayChange(_minDelay, newDelay);
+        _minDelay = newDelay;
+    }
+
+    /**
+     * @dev Encodes a `OperationState` into a `bytes32` representation where each bit enabled corresponds to
+     * the underlying position in the `OperationState` enum. For example:
+     *
+     * 0x000...1000
+     *   ^^^^^^----- ...
+     *         ^---- Done
+     *          ^--- Ready
+     *           ^-- Waiting
+     *            ^- Unset
+     */
+    function _encodeStateBitmap(OperationState operationState) internal pure returns (bytes32) {
+        return bytes32(1 << uint8(operationState));
+    }
+}

--- a/src/vendor/openzeppelin/token/ERC1155/IERC1155Receiver.sol
+++ b/src/vendor/openzeppelin/token/ERC1155/IERC1155Receiver.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.4.0) (token/ERC1155/IERC1155Receiver.sol)
+
+pragma solidity >=0.6.2;
+
+import {IERC165} from "../../utils/introspection/IERC165.sol";
+
+/**
+ * @dev Interface that must be implemented by smart contracts in order to receive
+ * ERC-1155 token transfers.
+ */
+interface IERC1155Receiver is IERC165 {
+    /**
+     * @dev Handles the receipt of a single ERC-1155 token type. This function is
+     * called at the end of a `safeTransferFrom` after the balance has been updated.
+     *
+     * NOTE: To accept the transfer, this must return
+     * `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`
+     * (i.e. 0xf23a6e61, or its own function selector).
+     *
+     * @param operator The address which initiated the transfer (i.e. msg.sender)
+     * @param from The address which previously owned the token
+     * @param id The ID of the token being transferred
+     * @param value The amount of tokens being transferred
+     * @param data Additional data with no specified format
+     * @return `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))` if transfer is allowed
+     */
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+    ) external returns (bytes4);
+
+    /**
+     * @dev Handles the receipt of a multiple ERC-1155 token types. This function
+     * is called at the end of a `safeBatchTransferFrom` after the balances have
+     * been updated.
+     *
+     * NOTE: To accept the transfer(s), this must return
+     * `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
+     * (i.e. 0xbc197c81, or its own function selector).
+     *
+     * @param operator The address which initiated the batch transfer (i.e. msg.sender)
+     * @param from The address which previously owned the token
+     * @param ids An array containing ids of each token being transferred (order and length must match values array)
+     * @param values An array containing amounts of each token being transferred (order and length must match ids array)
+     * @param data Additional data with no specified format
+     * @return `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` if transfer is allowed
+     */
+    function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    ) external returns (bytes4);
+}

--- a/src/vendor/openzeppelin/token/ERC1155/utils/ERC1155Holder.sol
+++ b/src/vendor/openzeppelin/token/ERC1155/utils/ERC1155Holder.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.5.0) (token/ERC1155/utils/ERC1155Holder.sol)
+
+pragma solidity ^0.8.20;
+
+import {IERC165, ERC165} from "../../../utils/introspection/ERC165.sol";
+import {IERC1155Receiver} from "../IERC1155Receiver.sol";
+
+/**
+ * @dev Simple implementation of `IERC1155Receiver` that will allow a contract to hold ERC-1155 tokens.
+ *
+ * IMPORTANT: When inheriting this contract, you must include a way to use the received tokens, otherwise they will be
+ * stuck.
+ *
+ * @custom:stateless
+ */
+abstract contract ERC1155Holder is ERC165, IERC1155Receiver {
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
+        return interfaceId == type(IERC1155Receiver).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    function onERC1155Received(
+        address,
+        address,
+        uint256,
+        uint256,
+        bytes memory
+    ) public virtual override returns (bytes4) {
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(
+        address,
+        address,
+        uint256[] memory,
+        uint256[] memory,
+        bytes memory
+    ) public virtual override returns (bytes4) {
+        return this.onERC1155BatchReceived.selector;
+    }
+}

--- a/src/vendor/openzeppelin/token/ERC721/IERC721Receiver.sol
+++ b/src/vendor/openzeppelin/token/ERC721/IERC721Receiver.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.4.0) (token/ERC721/IERC721Receiver.sol)
+
+pragma solidity >=0.5.0;
+
+/**
+ * @title ERC-721 token receiver interface
+ * @dev Interface for any contract that wants to support safeTransfers
+ * from ERC-721 asset contracts.
+ */
+interface IERC721Receiver {
+    /**
+     * @dev Whenever an {IERC721} `tokenId` token is transferred to this contract via {IERC721-safeTransferFrom}
+     * by `operator` from `from`, this function is called.
+     *
+     * It must return its Solidity selector to confirm the token transfer.
+     * If any other value is returned or the interface is not implemented by the recipient, the transfer will be
+     * reverted.
+     *
+     * The selector can be obtained in Solidity with `IERC721Receiver.onERC721Received.selector`.
+     */
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) external returns (bytes4);
+}

--- a/src/vendor/openzeppelin/token/ERC721/utils/ERC721Holder.sol
+++ b/src/vendor/openzeppelin/token/ERC721/utils/ERC721Holder.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.5.0) (token/ERC721/utils/ERC721Holder.sol)
+
+pragma solidity ^0.8.20;
+
+import {IERC721Receiver} from "../IERC721Receiver.sol";
+
+/**
+ * @dev Implementation of the {IERC721Receiver} interface.
+ *
+ * Accepts all token transfers.
+ * Make sure the contract is able to use its token with {IERC721-safeTransferFrom}, {IERC721-approve} or
+ * {IERC721-setApprovalForAll}.
+ *
+ * @custom:stateless
+ */
+abstract contract ERC721Holder is IERC721Receiver {
+    /**
+     * @dev See {IERC721Receiver-onERC721Received}.
+     *
+     * Always returns `IERC721Receiver.onERC721Received.selector`.
+     */
+    function onERC721Received(address, address, uint256, bytes memory) public virtual returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+}

--- a/src/vendor/openzeppelin/utils/Address.sol
+++ b/src/vendor/openzeppelin/utils/Address.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.5.0) (utils/Address.sol)
+
+pragma solidity ^0.8.20;
+
+import {Errors} from "./Errors.sol";
+import {LowLevelCall} from "./LowLevelCall.sol";
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev There's no code at `target` (it is not a contract).
+     */
+    error AddressEmptyCode(address target);
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.8.20/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        if (address(this).balance < amount) {
+            revert Errors.InsufficientBalance(address(this).balance, amount);
+        }
+        if (LowLevelCall.callNoReturn(recipient, amount, "")) {
+            // call successful, nothing to do
+            return;
+        } else if (LowLevelCall.returnDataSize() > 0) {
+            LowLevelCall.bubbleRevert();
+        } else {
+            revert Errors.FailedCall();
+        }
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain `call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason or custom error, it is bubbled
+     * up by this function (like regular Solidity function calls). However, if
+     * the call reverted with no returned reason, this function reverts with a
+     * {Errors.FailedCall} error.
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        if (address(this).balance < value) {
+            revert Errors.InsufficientBalance(address(this).balance, value);
+        }
+        bool success = LowLevelCall.callNoReturn(target, value, data);
+        if (success && (LowLevelCall.returnDataSize() > 0 || target.code.length > 0)) {
+            return LowLevelCall.returnData();
+        } else if (success) {
+            revert AddressEmptyCode(target);
+        } else if (LowLevelCall.returnDataSize() > 0) {
+            LowLevelCall.bubbleRevert();
+        } else {
+            revert Errors.FailedCall();
+        }
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        bool success = LowLevelCall.staticcallNoReturn(target, data);
+        if (success && (LowLevelCall.returnDataSize() > 0 || target.code.length > 0)) {
+            return LowLevelCall.returnData();
+        } else if (success) {
+            revert AddressEmptyCode(target);
+        } else if (LowLevelCall.returnDataSize() > 0) {
+            LowLevelCall.bubbleRevert();
+        } else {
+            revert Errors.FailedCall();
+        }
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        bool success = LowLevelCall.delegatecallNoReturn(target, data);
+        if (success && (LowLevelCall.returnDataSize() > 0 || target.code.length > 0)) {
+            return LowLevelCall.returnData();
+        } else if (success) {
+            revert AddressEmptyCode(target);
+        } else if (LowLevelCall.returnDataSize() > 0) {
+            LowLevelCall.bubbleRevert();
+        } else {
+            revert Errors.FailedCall();
+        }
+    }
+
+    /**
+     * @dev Tool to verify that a low level call to smart-contract was successful, and reverts if the target
+     * was not a contract or bubbling up the revert reason (falling back to {Errors.FailedCall}) in case
+     * of an unsuccessful call.
+     *
+     * NOTE: This function is DEPRECATED and may be removed in the next major release.
+     */
+    function verifyCallResultFromTarget(
+        address target,
+        bool success,
+        bytes memory returndata
+    ) internal view returns (bytes memory) {
+        // only check if target is a contract if the call was successful and the return data is empty
+        // otherwise we already know that it was a contract
+        if (success && (returndata.length > 0 || target.code.length > 0)) {
+            return returndata;
+        } else if (success) {
+            revert AddressEmptyCode(target);
+        } else if (returndata.length > 0) {
+            LowLevelCall.bubbleRevert(returndata);
+        } else {
+            revert Errors.FailedCall();
+        }
+    }
+
+    /**
+     * @dev Tool to verify that a low level call was successful, and reverts if it wasn't, either by bubbling the
+     * revert reason or with a default {Errors.FailedCall} error.
+     */
+    function verifyCallResult(bool success, bytes memory returndata) internal pure returns (bytes memory) {
+        if (success) {
+            return returndata;
+        } else if (returndata.length > 0) {
+            LowLevelCall.bubbleRevert(returndata);
+        } else {
+            revert Errors.FailedCall();
+        }
+    }
+}

--- a/src/vendor/openzeppelin/utils/Context.sol
+++ b/src/vendor/openzeppelin/utils/Context.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)
+
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+
+    function _contextSuffixLength() internal view virtual returns (uint256) {
+        return 0;
+    }
+}

--- a/src/vendor/openzeppelin/utils/Errors.sol
+++ b/src/vendor/openzeppelin/utils/Errors.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.1.0) (utils/Errors.sol)
+
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Collection of common custom errors used in multiple contracts
+ *
+ * IMPORTANT: Backwards compatibility is not guaranteed in future versions of the library.
+ * It is recommended to avoid relying on the error API for critical functionality.
+ *
+ * _Available since v5.1._
+ */
+library Errors {
+    /**
+     * @dev The ETH balance of the account is not enough to perform the operation.
+     */
+    error InsufficientBalance(uint256 balance, uint256 needed);
+
+    /**
+     * @dev A call to an address target failed. The target may have reverted.
+     */
+    error FailedCall();
+
+    /**
+     * @dev The deployment failed.
+     */
+    error FailedDeployment();
+
+    /**
+     * @dev A necessary precompile is missing.
+     */
+    error MissingPrecompile(address);
+}

--- a/src/vendor/openzeppelin/utils/LowLevelCall.sol
+++ b/src/vendor/openzeppelin/utils/LowLevelCall.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.6.0) (utils/LowLevelCall.sol)
+
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Library of low level call functions that implement different calling strategies to deal with the return data.
+ *
+ * WARNING: Using this library requires an advanced understanding of Solidity and how the EVM works. It is recommended
+ * to use the {Address} library instead.
+ */
+library LowLevelCall {
+    /// @dev Performs a Solidity function call using a low level `call` and ignoring the return data.
+    function callNoReturn(address target, bytes memory data) internal returns (bool success) {
+        return callNoReturn(target, 0, data);
+    }
+
+    /// @dev Same as {callNoReturn-address-bytes}, but allows specifying the value to be sent in the call.
+    function callNoReturn(address target, uint256 value, bytes memory data) internal returns (bool success) {
+        assembly ("memory-safe") {
+            success := call(gas(), target, value, add(data, 0x20), mload(data), 0x00, 0x00)
+        }
+    }
+
+    /// @dev Performs a Solidity function call using a low level `call` and returns the first 64 bytes of the result
+    /// in the scratch space of memory. Useful for functions that return a tuple with two single-word values.
+    ///
+    /// WARNING: Do not assume that the results are zero if `success` is false. Memory can be already allocated
+    /// and this function doesn't zero it out.
+    function callReturn64Bytes(
+        address target,
+        bytes memory data
+    ) internal returns (bool success, bytes32 result1, bytes32 result2) {
+        return callReturn64Bytes(target, 0, data);
+    }
+
+    /// @dev Same as {callReturn64Bytes-address-bytes}, but allows specifying the value to be sent in the call.
+    function callReturn64Bytes(
+        address target,
+        uint256 value,
+        bytes memory data
+    ) internal returns (bool success, bytes32 result1, bytes32 result2) {
+        assembly ("memory-safe") {
+            success := call(gas(), target, value, add(data, 0x20), mload(data), 0x00, 0x40)
+            result1 := mload(0x00)
+            result2 := mload(0x20)
+        }
+    }
+
+    /// @dev Performs a Solidity function call using a low level `staticcall` and ignoring the return data.
+    function staticcallNoReturn(address target, bytes memory data) internal view returns (bool success) {
+        assembly ("memory-safe") {
+            success := staticcall(gas(), target, add(data, 0x20), mload(data), 0x00, 0x00)
+        }
+    }
+
+    /// @dev Performs a Solidity function call using a low level `staticcall` and returns the first 64 bytes of the result
+    /// in the scratch space of memory. Useful for functions that return a tuple with two single-word values.
+    ///
+    /// WARNING: Do not assume that the results are zero if `success` is false. Memory can be already allocated
+    /// and this function doesn't zero it out.
+    function staticcallReturn64Bytes(
+        address target,
+        bytes memory data
+    ) internal view returns (bool success, bytes32 result1, bytes32 result2) {
+        assembly ("memory-safe") {
+            success := staticcall(gas(), target, add(data, 0x20), mload(data), 0x00, 0x40)
+            result1 := mload(0x00)
+            result2 := mload(0x20)
+        }
+    }
+
+    /// @dev Performs a Solidity function call using a low level `delegatecall` and ignoring the return data.
+    function delegatecallNoReturn(address target, bytes memory data) internal returns (bool success) {
+        assembly ("memory-safe") {
+            success := delegatecall(gas(), target, add(data, 0x20), mload(data), 0x00, 0x00)
+        }
+    }
+
+    /// @dev Performs a Solidity function call using a low level `delegatecall` and returns the first 64 bytes of the result
+    /// in the scratch space of memory. Useful for functions that return a tuple with two single-word values.
+    ///
+    /// WARNING: Do not assume that the results are zero if `success` is false. Memory can be already allocated
+    /// and this function doesn't zero it out.
+    function delegatecallReturn64Bytes(
+        address target,
+        bytes memory data
+    ) internal returns (bool success, bytes32 result1, bytes32 result2) {
+        assembly ("memory-safe") {
+            success := delegatecall(gas(), target, add(data, 0x20), mload(data), 0x00, 0x40)
+            result1 := mload(0x00)
+            result2 := mload(0x20)
+        }
+    }
+
+    /// @dev Returns the size of the return data buffer.
+    function returnDataSize() internal pure returns (uint256 size) {
+        assembly ("memory-safe") {
+            size := returndatasize()
+        }
+    }
+
+    /// @dev Returns a buffer containing the return data from the last call.
+    function returnData() internal pure returns (bytes memory result) {
+        assembly ("memory-safe") {
+            result := mload(0x40)
+            mstore(result, returndatasize())
+            returndatacopy(add(result, 0x20), 0x00, returndatasize())
+            mstore(0x40, add(result, add(0x20, returndatasize())))
+        }
+    }
+
+    /// @dev Revert with the return data from the last call.
+    function bubbleRevert() internal pure {
+        assembly ("memory-safe") {
+            let fmp := mload(0x40)
+            returndatacopy(fmp, 0x00, returndatasize())
+            revert(fmp, returndatasize())
+        }
+    }
+
+    function bubbleRevert(bytes memory returndata) internal pure {
+        assembly ("memory-safe") {
+            revert(add(returndata, 0x20), mload(returndata))
+        }
+    }
+}

--- a/src/vendor/openzeppelin/utils/introspection/ERC165.sol
+++ b/src/vendor/openzeppelin/utils/introspection/ERC165.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.4.0) (utils/introspection/ERC165.sol)
+
+pragma solidity ^0.8.20;
+
+import {IERC165} from "./IERC165.sol";
+
+/**
+ * @dev Implementation of the {IERC165} interface.
+ *
+ * Contracts that want to implement ERC-165 should inherit from this contract and override {supportsInterface} to check
+ * for the additional interface id that will be supported. For example:
+ *
+ * ```solidity
+ * function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+ *     return interfaceId == type(MyInterface).interfaceId || super.supportsInterface(interfaceId);
+ * }
+ * ```
+ */
+abstract contract ERC165 is IERC165 {
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IERC165).interfaceId;
+    }
+}

--- a/src/vendor/openzeppelin/utils/introspection/IERC165.sol
+++ b/src/vendor/openzeppelin/utils/introspection/IERC165.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.4.0) (utils/introspection/IERC165.sol)
+
+pragma solidity >=0.4.16;
+
+/**
+ * @dev Interface of the ERC-165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[ERC].
+ *
+ * Implementers can declare support of contract interfaces, which can then be
+ * queried by others ({ERC165Checker}).
+ *
+ * For an implementation, see {ERC165}.
+ */
+interface IERC165 {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}


### PR DESCRIPTION
## Summary

Phase 6 of the post-audit improvement plan: timelocks for administrative operations + Fordefi MCP role architecture.

**This PR is draft. Spec must be reviewed before implementation lands.**

## What's in here so far

- [x] `docs/timelock-and-governance-spec.md` — design contract
- [ ] OZ TimelockController vendored under `src/vendor/openzeppelin/governance/`
- [ ] TimelockController integration on UUPS contracts (`_authorizeUpgrade` gating)
- [ ] Operations Timelock setter gating (treasury/fee/MultiFacetProxy)
- [ ] Migration script + tests
- [ ] Architecture doc update (`docs/architecture.md`)

## How to review

Start with [`docs/timelock-and-governance-spec.md`](https://github.com/turingcapitalgroup/kam/blob/post-audit-phase-6/docs/timelock-and-governance-spec.md) — that's the contract this PR implements against. Sign-off in §10 of the spec is the gate before code review starts on subsequent commits.

Open items (§8 of spec) requiring decisions:
1. ADMIN multisig configuration (suggested 3-of-5)
2. SmartAdapterAccount upgrade authority — Admin Timelock vs per-strategy
3. OpenZeppelin Contracts version to pin
4. MultiFacetProxy gating granularity

## Test plan
- [ ] `forge build` clean after vendoring
- [ ] Unit tests per-timelock (propose, execute, cancel, updateDelay)
- [ ] Integration tests per-gated-function
- [ ] Emergency-exemption tests
- [ ] Migration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)