### PR TITLE
Post audit phase 8: VaultAdapter global pause

### DIFF
--- a/src/adapters/VaultAdapter.sol
+++ b/src/adapters/VaultAdapter.sol
@@ -120,9 +120,13 @@ contract VaultAdapter is SmartAdapterAccount, IVaultAdapter {
                               INTERNAL VIEW
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Ensures the contract is not paused
+    /// @notice Ensures neither the local adapter pause nor the registry-wide global pause is active
     function _checkPaused(VaultAdapterStorage storage $) internal view {
-        require(!$.paused, VAULTADAPTER_IS_PAUSED);
+        require(
+            !$.paused
+                && !IkRegistry(address(_getMinimalAccountStorage().registry)).isGlobalPaused(),
+            VAULTADAPTER_IS_PAUSED
+        );
     }
 
     /// @notice Ensures the caller is the kAssetRouter

--- a/test/unit/VaultAdapter.t.sol
+++ b/test/unit/VaultAdapter.t.sol
@@ -6,8 +6,11 @@ import { _1_USDC } from "../utils/Constants.sol";
 import { DeploymentBaseTest } from "../utils/DeploymentBaseTest.sol";
 
 import { VaultAdapter } from "kam/src/adapters/VaultAdapter.sol";
-import { VAULTADAPTER_WRONG_ROLE, VAULTADAPTER_ZERO_ADDRESS } from "kam/src/errors/Errors.sol";
+import { VAULTADAPTER_IS_PAUSED, VAULTADAPTER_WRONG_ROLE, VAULTADAPTER_ZERO_ADDRESS } from "kam/src/errors/Errors.sol";
 import { IVaultAdapter } from "kam/src/interfaces/IVaultAdapter.sol";
+import { Execution } from "minimal-smart-account/interfaces/IMinimalSmartAccount.sol";
+import { ExecutionLib } from "minimal-smart-account/libraries/ExecutionLib.sol";
+import { ModeLib } from "minimal-smart-account/libraries/ModeLib.sol";
 import { Ownable } from "solady/auth/Ownable.sol";
 
 contract VaultAdapterTest is DeploymentBaseTest {
@@ -131,6 +134,86 @@ contract VaultAdapterTest is DeploymentBaseTest {
         vm.prank(users.admin);
         vm.expectRevert(bytes(VAULTADAPTER_WRONG_ROLE));
         adapter.pull(USDC, _amount);
+    }
+
+    /* //////////////////////////////////////////////////////////////
+                            PAUSE COVERAGE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Local adapter pause must halt asset operations.
+    function test_Pull_LocalPaused_Reverts() public {
+        uint256 _amount = 100 * _1_USDC;
+        mockUSDC.mint(address(adapter), _amount);
+
+        vm.prank(users.emergencyAdmin);
+        adapter.setPaused(true);
+
+        vm.prank(address(assetRouter));
+        vm.expectRevert(bytes(VAULTADAPTER_IS_PAUSED));
+        adapter.pull(USDC, _amount);
+    }
+
+    /// @notice Registry-wide global pause must halt adapter operations even when
+    /// the local adapter pause flag is unset. Without this, a global pause does
+    /// not stop strategy execution / asset egress through the adapter.
+    function test_Pull_GlobalPaused_Reverts() public {
+        uint256 _amount = 100 * _1_USDC;
+        mockUSDC.mint(address(adapter), _amount);
+
+        vm.prank(users.emergencyAdmin);
+        registry.setGlobalPause(true);
+
+        vm.prank(address(assetRouter));
+        vm.expectRevert(bytes(VAULTADAPTER_IS_PAUSED));
+        adapter.pull(USDC, _amount);
+    }
+
+    /// @notice With neither pause active, the asset operation proceeds.
+    function test_Pull_BothUnpaused_Succeeds() public {
+        uint256 _amount = 100 * _1_USDC;
+        mockUSDC.mint(address(adapter), _amount);
+
+        assertFalse(registry.isGlobalPaused());
+
+        uint256 _balanceBefore = mockUSDC.balanceOf(address(assetRouter));
+
+        vm.prank(address(assetRouter));
+        adapter.pull(USDC, _amount);
+
+        assertEq(mockUSDC.balanceOf(address(assetRouter)), _balanceBefore + _amount);
+    }
+
+    /// @notice Local adapter pause must halt strategy execution.
+    /// @dev Mirrors `test_Pull_LocalPaused_Reverts` at the `execute()` entry point
+    /// — the audit-doc-named coverage of `_authorizeExecute`'s pause check.
+    function test_Execute_LocalPaused_Reverts() public {
+        Execution[] memory _executions = new Execution[](1);
+        _executions[0] = Execution({ target: USDC, value: 0, callData: "" });
+        bytes memory _executionCalldata = ExecutionLib.encodeBatch(_executions);
+
+        vm.prank(users.emergencyAdmin);
+        adapter.setPaused(true);
+
+        vm.prank(users.relayer);
+        vm.expectRevert(bytes(VAULTADAPTER_IS_PAUSED));
+        adapter.execute(ModeLib.encodeSimpleBatch(), _executionCalldata);
+    }
+
+    /// @notice Registry-wide global pause must halt strategy execution. This is the
+    /// regression test for the audit finding: prior to Phase 8, `_authorizeExecute`
+    /// only checked the local pause flag, so a global pause did not stop adapter
+    /// strategy execution.
+    function test_Execute_GlobalPaused_Reverts() public {
+        Execution[] memory _executions = new Execution[](1);
+        _executions[0] = Execution({ target: USDC, value: 0, callData: "" });
+        bytes memory _executionCalldata = ExecutionLib.encodeBatch(_executions);
+
+        vm.prank(users.emergencyAdmin);
+        registry.setGlobalPause(true);
+
+        vm.prank(users.relayer);
+        vm.expectRevert(bytes(VAULTADAPTER_IS_PAUSED));
+        adapter.execute(ModeLib.encodeSimpleBatch(), _executionCalldata);
     }
 
     /* //////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Audit finding (Codebase Maturity — Auditing, pause consistency section): `VaultAdapter._authorizeExecute` checked only the local adapter pause flag and ignored `registry.isGlobalPaused()`, so a global pause did **not** halt adapter strategy execution.

## Fix

Extended the shared `_checkPaused` helper in `VaultAdapter` to also check the registry's global pause. Both call sites (`_authorizeExecute` and `pull`) now respect global pause.

```solidity
function _checkPaused(VaultAdapterStorage storage $) internal view {
    require(
        !$.paused
            && !IkRegistry(address(_getMinimalAccountStorage().registry)).isGlobalPaused(),
        VAULTADAPTER_IS_PAUSED
    );
}
```

### Implementation deviation from audit doc — intentional

The audit doc shows the fix inlined into `_authorizeExecute`. This PR instead extends the shared `_checkPaused` helper. Reasoning:

- `_checkPaused` is called by both `_authorizeExecute` (via `execute()`) and `pull()` directly. Inlining only into `_authorizeExecute` would leave `pull()` unprotected.
- Single source of truth — future-proof if more call sites are added.
- Same gas shape (one extra external view call), same revert message.

Net effect: broader fix than the audit literally specified, no regressions.

## Tests (6 new, 17 passing in VaultAdapterTest)

Audit-doc-named coverage at the `execute()` entry point:
- `test_Execute_LocalPaused_Reverts`
- `test_Execute_GlobalPaused_Reverts` — regression test for the original audit finding

Helper-level coverage at the `pull()` entry point (same `_checkPaused`):
- `test_Pull_LocalPaused_Reverts`
- `test_Pull_GlobalPaused_Reverts`
- `test_Pull_BothUnpaused_Succeeds`

## Test plan
- [x] `forge build` clean
- [x] `forge test --match-contract VaultAdapterTest` — 17/17 pass
- [x] `forge test --no-match-test invariant` — 625/625 pass, no regressions in existing execute integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)