### PR TITLE
fix(kRemoteRegistry): revert idempotent disallow instead of underflowing counter

### DIFF
--- a/src/kRegistry/kRemoteRegistry.sol
+++ b/src/kRegistry/kRemoteRegistry.sol
@@ -96,7 +96,7 @@ contract kRemoteRegistry is IkRemoteRegistry, Initializable, UUPSUpgradeable, Ow
 
         // Check if trying to set to the same value
         bool _currentlyAllowed = $.executorAllowedSelectors[_executor][_target][_selector];
-        require(!(_currentlyAllowed && _allowed), KREMOTEREGISTRY_SELECTOR_ALREADY_SET);
+        require(_currentlyAllowed != _allowed, KREMOTEREGISTRY_SELECTOR_ALREADY_SET);
 
         $.executorAllowedSelectors[_executor][_target][_selector] = _allowed;
 

--- a/test/unit/kRemoteRegistry.t.sol
+++ b/test/unit/kRemoteRegistry.t.sol
@@ -121,6 +121,12 @@ contract kRemoteRegistryTest is Test {
         registry.setAllowedSelector(executor, target, testSelector, true);
     }
 
+    function test_SetAllowedSelector_Require_Not_Already_Disallowed() public {
+        vm.prank(owner);
+        vm.expectRevert(bytes(KREMOTEREGISTRY_SELECTOR_ALREADY_SET));
+        registry.setAllowedSelector(executor, target, testSelector, false);
+    }
+
     /* //////////////////////////////////////////////////////////////
                     EXECUTION VALIDATOR
     //////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
## Summary
- `setAllowedSelector(executor, target, selector, false)` panicked with arithmetic underflow (0x11) when the selector was never allowed for that pair — the existing guard at [kRemoteRegistry.sol:99](src/kRegistry/kRemoteRegistry.sol#L99) only caught the `(currentlyAllowed=true, _allowed=true)` case, so `(false, false)` fell through to the `else` branch and decremented `executorTargetSelectorCount` from zero.
- Tighten the guard to `require(_currentlyAllowed != _allowed, KREMOTEREGISTRY_SELECTOR_ALREADY_SET)` so both `(true,true)` and `(false,false)` revert cleanly. The `(false,false)` state IS "already set to disallowed", so reusing the existing `RR4` error fits the semantics.
- Add `test_SetAllowedSelector_Require_Not_Already_Disallowed` covering the previously buggy path.

## Why reuse the existing error
- The error name (`KREMOTEREGISTRY_SELECTOR_ALREADY_SET`) and code (`RR4`) already mean "no state change needed" — that fits both no-op directions.
- Avoids adding a new error code just for a symmetric edge case.

## Repro (before fix)
```solidity
function test_DisallowAlreadyDisallowed() public {
    vm.prank(owner);
    registry.setAllowedSelector(address(0x1), address(0x2), bytes4(0xdeadbeef), false);
    // panics: 0x11 underflow on executorTargetSelectorCount[_executor][_target]--
}
```

## Backward compatibility
- `(true, true)`: still reverts with `KREMOTEREGISTRY_SELECTOR_ALREADY_SET` — unchanged.
- `(true, false)`: still flips to disallowed — unchanged.
- `(false, true)`: still flips to allowed — unchanged.
- `(false, false)`: previously underflowed; now reverts with `KREMOTEREGISTRY_SELECTOR_ALREADY_SET` — bug fix.

All non-test callers in `script/deployment/11_ConfigureExecutorPermissions.s.sol` only pass `_allowed=true` for fresh permissions, so no deployment caller relied on the buggy path.

## Test plan
- [x] `forge test --match-contract kRemoteRegistryTest` — all 27 tests pass on this branch (8 `setAllowedSelector` tests including the new one).
- [x] Existing `test_SetAllowedSelector_Require_Not_Already_Set` (true→true) still reverts with same error.
- [x] Existing `test_SetAllowedSelector_Disallow_Success` (true→false) still flips and emits.
- [x] New `test_SetAllowedSelector_Require_Not_Already_Disallowed` (false→false) reverts with `KREMOTEREGISTRY_SELECTOR_ALREADY_SET`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)