### PR TITLE
fix: post-audit phase 12 - deployment hardening and safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export
 # Foundry profile for deployments (uses optimizer settings)
 DEPLOY_PROFILE = deploy
 
-.PHONY: help deploy-mainnet deploy-mainnet-dry-run deploy-sepolia deploy-sepolia-dry-run deploy-localhost deploy-localhost-dry-run config-mainnet config-mainnet-dry-run config-sepolia config-sepolia-dry-run config-localhost config-localhost-dry-run deploy-all config-all deploy-mock-assets verify-mainnet verify-sepolia verify clean clean-all configure-adapters register-modules format-output test test-parallel coverage gas-estimations deploy-phase1-sepolia deploy-phase1-sepolia-dry-run deploy-phase1-mainnet deploy-phase1-mainnet-dry-run config-phase2-sepolia config-phase2-sepolia-dry-run config-phase2-mainnet config-phase2-mainnet-dry-run
+.PHONY: help anvil-localhost deploy-mainnet deploy-mainnet-dry-run deploy-sepolia deploy-sepolia-dry-run deploy-localhost deploy-localhost-dry-run config-mainnet config-mainnet-dry-run config-sepolia config-sepolia-dry-run config-localhost config-localhost-dry-run deploy-all config-all deploy-mock-assets verify-mainnet verify-sepolia verify clean clean-all configure-adapters register-modules format-output test test-parallel coverage gas-estimations deploy-phase1-sepolia deploy-phase1-sepolia-dry-run deploy-phase1-mainnet deploy-phase1-mainnet-dry-run config-phase2-sepolia config-phase2-sepolia-dry-run config-phase2-mainnet config-phase2-mainnet-dry-run
 
 # Default target
 help:
@@ -15,6 +15,7 @@ help:
 	@echo ""
 	@echo "=== LOCALHOST (Full deployment with mocks) ==="
 	@echo "make deploy-localhost        - Deploy everything to localhost (includes mocks)"
+	@echo "make anvil-localhost         - Start Anvil with the flags required by localhost deploy"
 	@echo "make deploy-localhost-dry-run- Simulate deployment (no broadcast)"
 	@echo "make config-localhost        - Configure protocol on localhost"
 	@echo "make config-localhost-dry-run- Simulate configuration (no broadcast)"
@@ -61,6 +62,10 @@ help:
 	@echo "make configure-adapters   - Configure adapter permissions (11)"
 	@echo "make configure-approvals  - Configure adapter ERC20 approvals (12)"
 
+anvil-localhost:
+	@echo "Starting localhost Anvil with deployment-compatible settings..."
+	anvil --host 127.0.0.1 --port 8545 --chain-id 31337 --disable-code-size-limit
+
 # Network-specific deployments
 deploy-mainnet:
 	@echo "🔴 Deploying to MAINNET..."
@@ -82,13 +87,13 @@ deploy-sepolia-dry-run:
 
 deploy-localhost:
 	@echo "🟢 Deploying to LOCALHOST..."
-	@$(MAKE) deploy-mock-assets FORGE_ARGS="--rpc-url http://localhost:8545 --broadcast --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --slow"
-	@$(MAKE) deploy-all FORGE_ARGS="--rpc-url http://localhost:8545 --broadcast --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --slow"
+	@$(MAKE) deploy-mock-assets FORGE_ARGS="--rpc-url http://localhost:8545 --broadcast --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --slow --disable-code-size-limit"
+	@$(MAKE) deploy-all FORGE_ARGS="--rpc-url http://localhost:8545 --broadcast --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --slow --disable-code-size-limit"
 
 deploy-localhost-dry-run:
 	@echo "🟢 [DRY-RUN] Simulating deployment to LOCALHOST..."
-	@$(MAKE) deploy-mock-assets FORGE_ARGS="--rpc-url http://localhost:8545 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --slow"
-	@$(MAKE) deploy-all FORGE_ARGS="--rpc-url http://localhost:8545 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --slow"
+	@$(MAKE) deploy-mock-assets FORGE_ARGS="--rpc-url http://localhost:8545 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --slow --disable-code-size-limit"
+	@$(MAKE) deploy-all FORGE_ARGS="--rpc-url http://localhost:8545 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --slow --disable-code-size-limit"
 
 # ========================================
 # TWO-PHASE DEPLOYMENT (Sepolia/Mainnet)

--- a/deployments/config/localhost.json
+++ b/deployments/config/localhost.json
@@ -21,7 +21,10 @@
   },
   "custodialTargets": {
     "walletUSDC": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
-    "walletWBTC": "0x0000000000000000000000000000000000000000"
+    "walletWBTC": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"
+  },
+  "minter": {
+    "vaultType": "MINTER"
   },
   "kTokens": {
     "kUSD": {
@@ -45,10 +48,11 @@
       "symbol": "dnkUSD",
       "decimals": 6,
       "underlyingAsset": "USDC",
+      "vaultType": "DN",
       "startPaused": false,
-      "maxTotalAssets": 500000000000000,
+      "maxTotalAssets": "500000000000000",
       "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-      "maxWithdrawPerBatch": 50000000000000,
+      "maxWithdrawPerBatch": "50000000000000",
       "trustedForwarder": "0x717AF6845eA3d3A84F22b54E5744AC25EF224C92",
       "hurdleRate": 500,
       "isHardHurdleRate": false
@@ -58,10 +62,11 @@
       "symbol": "dnkBTC",
       "decimals": 8,
       "underlyingAsset": "WBTC",
+      "vaultType": "DN",
       "startPaused": false,
-      "maxTotalAssets": 20000000000,
+      "maxTotalAssets": "20000000000",
       "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-      "maxWithdrawPerBatch": 2000000000,
+      "maxWithdrawPerBatch": "2000000000",
       "trustedForwarder": "0x717AF6845eA3d3A84F22b54E5744AC25EF224C92",
       "hurdleRate": 500,
       "isHardHurdleRate": false
@@ -71,10 +76,11 @@
       "symbol": "akUSD",
       "decimals": 6,
       "underlyingAsset": "USDC",
+      "vaultType": "ALPHA",
       "startPaused": false,
       "maxTotalAssets": "200000000000000",
       "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-      "maxWithdrawPerBatch": 20000000000000,
+      "maxWithdrawPerBatch": "20000000000000",
       "trustedForwarder": "0x717AF6845eA3d3A84F22b54E5744AC25EF224C92",
       "hurdleRate": 500,
       "isHardHurdleRate": false
@@ -84,13 +90,40 @@
       "symbol": "bkUSD",
       "decimals": 6,
       "underlyingAsset": "USDC",
+      "vaultType": "BETA",
       "startPaused": false,
-      "maxTotalAssets": 200000000000000,
+      "maxTotalAssets": "200000000000000",
       "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-      "maxWithdrawPerBatch": 20000000000000,
+      "maxWithdrawPerBatch": "20000000000000",
       "trustedForwarder": "0x717AF6845eA3d3A84F22b54E5744AC25EF224C92",
       "hurdleRate": 500,
       "isHardHurdleRate": false
+    }
+  },
+  "adapters": {
+    "dnVaultAdapterUSDC": {
+      "namespace": "kam.dnVault.usdc",
+      "owner": "config:roles.owner"
+    },
+    "dnVaultAdapterWBTC": {
+      "namespace": "kam.dnVault.wbtc",
+      "owner": "config:roles.owner"
+    },
+    "alphaVaultAdapter": {
+      "namespace": "kam.alphaVault.usdc",
+      "owner": "config:roles.owner"
+    },
+    "betaVaultAdapter": {
+      "namespace": "kam.betaVault.usdc",
+      "owner": "config:roles.owner"
+    },
+    "kMinterAdapterUSDC": {
+      "namespace": "kam.minter.usdc",
+      "owner": "config:roles.owner"
+    },
+    "kMinterAdapterWBTC": {
+      "namespace": "kam.minter.wbtc",
+      "owner": "config:roles.owner"
     }
   },
   "registry": {
@@ -116,7 +149,7 @@
         "betaVaultAdapter"
       ],
       "WBTC": [
-        "walletUSDC",
+        "walletWBTC",
         "dnVaultAdapterWBTC"
       ],
       "metawalletUSDC": [

--- a/deployments/config/mainnet.json
+++ b/deployments/config/mainnet.json
@@ -12,8 +12,8 @@
     "insurance": "0x0000000000000000000000000000000000000008"
   },
   "assets": {
-    "USDC": "0xA0b86a33E6d8c30c9b61aEB5eF6c5C756fA2A45F1",
-    "WBTC": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
+    "USDC": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "WBTC": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
   },
   "metawallets": {
     "USDC": "0x0000000000000000000000000000000000000000",
@@ -22,6 +22,9 @@
   "custodialTargets": {
     "walletUSDC": "0x0000000000000000000000000000000000000000",
     "walletWBTC": "0x0000000000000000000000000000000000000000"
+  },
+  "minter": {
+    "vaultType": "MINTER"
   },
   "kTokens": {
     "kUSD": {
@@ -45,10 +48,11 @@
       "symbol": "dnkUSD",
       "decimals": 6,
       "underlyingAsset": "USDC",
+      "vaultType": "DN",
       "startPaused": false,
-      "maxTotalAssets": 500000000000000,
+      "maxTotalAssets": "500000000000000",
       "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-      "maxWithdrawPerBatch": 50000000000000,
+      "maxWithdrawPerBatch": "50000000000000",
       "trustedForwarder": "0x0000000000000000000000000000000000000000",
       "hurdleRate": 500,
       "isHardHurdleRate": false
@@ -58,10 +62,11 @@
       "symbol": "dnkBTC",
       "decimals": 8,
       "underlyingAsset": "WBTC",
+      "vaultType": "DN",
       "startPaused": false,
-      "maxTotalAssets": 20000000000,
+      "maxTotalAssets": "20000000000",
       "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-      "maxWithdrawPerBatch": 2000000000,
+      "maxWithdrawPerBatch": "2000000000",
       "trustedForwarder": "0x0000000000000000000000000000000000000000",
       "hurdleRate": 500,
       "isHardHurdleRate": false
@@ -71,10 +76,11 @@
       "symbol": "akUSD",
       "decimals": 6,
       "underlyingAsset": "USDC",
+      "vaultType": "ALPHA",
       "startPaused": false,
       "maxTotalAssets": "200000000000000",
       "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-      "maxWithdrawPerBatch": 20000000000000,
+      "maxWithdrawPerBatch": "20000000000000",
       "trustedForwarder": "0x0000000000000000000000000000000000000000",
       "hurdleRate": 500,
       "isHardHurdleRate": false
@@ -84,13 +90,40 @@
       "symbol": "bkUSD",
       "decimals": 6,
       "underlyingAsset": "USDC",
+      "vaultType": "BETA",
       "startPaused": false,
-      "maxTotalAssets": 200000000000000,
+      "maxTotalAssets": "200000000000000",
       "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-      "maxWithdrawPerBatch": 20000000000000,
+      "maxWithdrawPerBatch": "20000000000000",
       "trustedForwarder": "0x0000000000000000000000000000000000000000",
       "hurdleRate": 500,
       "isHardHurdleRate": false
+    }
+  },
+  "adapters": {
+    "dnVaultAdapterUSDC": {
+      "namespace": "kam.dnVault.usdc",
+      "owner": "config:roles.owner"
+    },
+    "dnVaultAdapterWBTC": {
+      "namespace": "kam.dnVault.wbtc",
+      "owner": "config:roles.owner"
+    },
+    "alphaVaultAdapter": {
+      "namespace": "kam.alphaVault.usdc",
+      "owner": "config:roles.owner"
+    },
+    "betaVaultAdapter": {
+      "namespace": "kam.betaVault.usdc",
+      "owner": "config:roles.owner"
+    },
+    "kMinterAdapterUSDC": {
+      "namespace": "kam.minter.usdc",
+      "owner": "config:roles.owner"
+    },
+    "kMinterAdapterWBTC": {
+      "namespace": "kam.minter.wbtc",
+      "owner": "config:roles.owner"
     }
   },
   "registry": {
@@ -98,7 +131,7 @@
     "insuranceBps": 500
   },
   "assetRouter": {
-    "settlementCooldown": 0,
+    "settlementCooldown": 3600,
     "maxAllowedDelta": 1000
   },
   "parameterChecker": {
@@ -110,7 +143,7 @@
     },
     "allowedReceivers": {
       "USDC": ["walletUSDC", "dnVaultAdapterUSDC", "alphaVaultAdapter", "betaVaultAdapter"],
-      "WBTC": ["walletUSDC", "dnVaultAdapterWBTC"],
+      "WBTC": ["walletWBTC", "dnVaultAdapterWBTC"],
       "metawalletUSDC": ["kMinterAdapterUSDC", "dnVaultAdapterUSDC"],
       "metawalletWBTC": ["kMinterAdapterWBTC", "dnVaultAdapterWBTC"]
     },

--- a/deployments/config/sepolia.json
+++ b/deployments/config/sepolia.json
@@ -3,13 +3,13 @@
     "chainId": 11155111,
     "roles": {
         "owner": "0x11D5E7dBA0658cAE21BEAA6a1719975cB233A81E",
-        "admin": "0x11D5E7dBA0658cAE21BEAA6a1719975cB233A81E",
-        "emergencyAdmin": "0x11D5E7dBA0658cAE21BEAA6a1719975cB233A81E",
-        "guardian": "0x11D5E7dBA0658cAE21BEAA6a1719975cB233A81E",
+        "admin": "0x0000000000000000000000000000000000000101",
+        "emergencyAdmin": "0x0000000000000000000000000000000000000102",
+        "guardian": "0x0000000000000000000000000000000000000103",
         "relayer": "0x11D5E7dBA0658cAE21BEAA6a1719975cB233A81E",
         "institution": "0x11D5E7dBA0658cAE21BEAA6a1719975cB233A81E",
-        "treasury": "0x11D5E7dBA0658cAE21BEAA6a1719975cB233A81E",
-        "insurance": "0x11D5E7dBA0658cAE21BEAA6a1719975cB233A81E"
+        "treasury": "0x0000000000000000000000000000000000000104",
+        "insurance": "0x0000000000000000000000000000000000000105"
     },
     "assets": {
         "USDC": "0x028B671ED42278312764195434B21f87Ef8DB422",
@@ -22,6 +22,9 @@
     "custodialTargets": {
         "walletUSDC": "0xB1Ff792A9eFCd1DaA951701b5860421259098d05",
         "walletWBTC": "0xB1Ff792A9eFCd1DaA951701b5860421259098d05"
+    },
+    "minter": {
+        "vaultType": "MINTER"
     },
     "kTokens": {
         "kUSD": {
@@ -45,10 +48,11 @@
             "symbol": "dnkUSD",
             "decimals": 6,
             "underlyingAsset": "USDC",
+            "vaultType": "DN",
             "startPaused": false,
-            "maxTotalAssets": 500000000000000,
+            "maxTotalAssets": "500000000000000",
             "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-            "maxWithdrawPerBatch": 50000000000000,
+            "maxWithdrawPerBatch": "50000000000000",
             "trustedForwarder": "0x0000000000000000000000000000000000000000",
             "hurdleRate": 500,
             "isHardHurdleRate": false
@@ -58,10 +62,11 @@
             "symbol": "dnkBTC",
             "decimals": 8,
             "underlyingAsset": "WBTC",
+            "vaultType": "DN",
             "startPaused": false,
-            "maxTotalAssets": 20000000000,
+            "maxTotalAssets": "20000000000",
             "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-            "maxWithdrawPerBatch": 2000000000,
+            "maxWithdrawPerBatch": "2000000000",
             "trustedForwarder": "0x0000000000000000000000000000000000000000",
             "hurdleRate": 500,
             "isHardHurdleRate": false
@@ -71,10 +76,11 @@
             "symbol": "akUSD",
             "decimals": 6,
             "underlyingAsset": "USDC",
+            "vaultType": "ALPHA",
             "startPaused": false,
             "maxTotalAssets": "200000000000000",
             "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-            "maxWithdrawPerBatch": 20000000000000,
+            "maxWithdrawPerBatch": "20000000000000",
             "trustedForwarder": "0x0000000000000000000000000000000000000000",
             "hurdleRate": 500,
             "isHardHurdleRate": false
@@ -84,13 +90,40 @@
             "symbol": "bkUSD",
             "decimals": 6,
             "underlyingAsset": "USDC",
+            "vaultType": "BETA",
             "startPaused": false,
-            "maxTotalAssets": 200000000000000,
+            "maxTotalAssets": "200000000000000",
             "maxDepositPerBatch": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-            "maxWithdrawPerBatch": 20000000000000,
+            "maxWithdrawPerBatch": "20000000000000",
             "trustedForwarder": "0x0000000000000000000000000000000000000000",
             "hurdleRate": 500,
             "isHardHurdleRate": false
+        }
+    },
+    "adapters": {
+        "dnVaultAdapterUSDC": {
+            "namespace": "kam.dnVault.usdc",
+            "owner": "config:roles.owner"
+        },
+        "dnVaultAdapterWBTC": {
+            "namespace": "kam.dnVault.wbtc",
+            "owner": "config:roles.owner"
+        },
+        "alphaVaultAdapter": {
+            "namespace": "kam.alphaVault.usdc",
+            "owner": "config:roles.owner"
+        },
+        "betaVaultAdapter": {
+            "namespace": "kam.betaVault.usdc",
+            "owner": "config:roles.owner"
+        },
+        "kMinterAdapterUSDC": {
+            "namespace": "kam.minter.usdc",
+            "owner": "config:roles.owner"
+        },
+        "kMinterAdapterWBTC": {
+            "namespace": "kam.minter.wbtc",
+            "owner": "config:roles.owner"
         }
     },
     "registry": {
@@ -98,7 +131,7 @@
         "insuranceBps": 500
     },
     "assetRouter": {
-        "settlementCooldown": 0,
+        "settlementCooldown": 3600,
         "maxAllowedDelta": 1000
     },
     "parameterChecker": {
@@ -116,7 +149,7 @@
                 "betaVaultAdapter"
             ],
             "WBTC": [
-                "walletUSDC",
+                "walletWBTC",
                 "dnVaultAdapterWBTC"
             ],
             "metawalletUSDC": [

--- a/deployments/output/localhost/addresses.json
+++ b/deployments/output/localhost/addresses.json
@@ -3,6 +3,7 @@
   "contracts": {
     "MinimalUUPSFactory": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
     "WalletUSDC": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
+    "WalletWBTC": "0x0000000000000000000000000000000000000000",
     "adapterGuardianModule": "0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1",
     "alphaVault": "0x46A9cF43B44f5CEb06747aF10955A02fD6671783",
     "alphaVaultAdapter": "0xc72500B2CA87DF8f964662A6bd3E4D94fA6Cf90d",
@@ -12,8 +13,8 @@
     "dnVaultAdapterWBTC": "0x9ace813B1adA8a75DF6518A6d1b50f1A418CdAB7",
     "dnVaultUSDC": "0x436932D6361Db21CbDf440A39046093a1C12D2B4",
     "dnVaultWBTC": "0x235B28c74f19083a5CAce20C506513417a90BE29",
-    "erc20ExecutionValidator": "0x8F4ec854Dd12F1fe79500a1f53D0cbB30f9b6134",
-    "erc4626ExecutionValidator": "0xC66AB83418C20A65C3f8e83B3d11c8C3a6097b6F",
+    "erc20ExecutionValidator": "0x2B0d36FACD61B71CC05ab8F3D2355ec3631C0dd5",
+    "erc4626ExecutionValidator": "0xfbC22278A96299D91d41C453234d97b4F5Eb9B2d",
     "insuranceSmartAccount": "0xc6d011391f42EBB7bE9454d549FbB170BD4Fc0e7",
     "kAssetRouter": "0x05242D4AC717Cdf38C36AF290F2b0DA99AA82c67",
     "kAssetRouterImpl": "0xc6e7DF5E7b4f2A278906862b61205850344D4e7d",
@@ -34,5 +35,5 @@
     "vaultAdapterImpl": "0x95401dc811bb5740090279Ba06cfA8fcF6113778"
   },
   "network": "localhost",
-  "timestamp": 1777462115
+  "timestamp": 1777975255
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,7 +18,7 @@ fs_permissions = [{ access = "read-write", path = "." }]
 solc_version = "0.8.30"
 via_ir = true
 optimizer = true
-optimizer_runs = 5000
+optimizer_runs = 800
 
 [profile.solx]
 gas_limit = 100_000_000

--- a/script/README.md
+++ b/script/README.md
@@ -55,8 +55,8 @@ deployments/
     "treasury": "0x..."
   },
   "assets": {
-    "USDC": "0xA0b86a33E6d8c30c9b61aEB5eF6c5C756fA2A45F1",
-    "WBTC": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
+    "USDC": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "WBTC": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
   }
 }
 ```

--- a/script/deployment/00_DeployMockAssets.s.sol
+++ b/script/deployment/00_DeployMockAssets.s.sol
@@ -172,6 +172,7 @@ contract DeployMockAssetsScript is Script, DeploymentManager {
         // 3. Update the MockWallet Address (both locations for consistency)
         vm.writeJson(vm.toString(mockWalletUSDC), configPath, ".mockAssets.WalletUSDC");
         vm.writeJson(vm.toString(mockWalletUSDC), configPath, ".custodialTargets.walletUSDC");
+        vm.writeJson(vm.toString(mockWalletUSDC), configPath, ".custodialTargets.walletWBTC");
 
         _log("Updated config file with mock asset addresses");
     }

--- a/script/deployment/02_DeployMinter.s.sol
+++ b/script/deployment/02_DeployMinter.s.sol
@@ -28,6 +28,7 @@ contract DeployMinterScript is Script, DeploymentManager {
     {
         // Read network configuration
         NetworkConfig memory config = readNetworkConfig();
+        validateConfig(config);
         DeploymentOutput memory existing;
 
         // If addresses not provided, read from JSON (for real deployments)

--- a/script/deployment/03_DeployAssetRouter.s.sol
+++ b/script/deployment/03_DeployAssetRouter.s.sol
@@ -28,6 +28,7 @@ contract DeployAssetRouterScript is Script, DeploymentManager {
     {
         // Read network configuration
         NetworkConfig memory config = readNetworkConfig();
+        validateConfig(config);
         DeploymentOutput memory existing;
 
         // If addresses not provided, read from JSON (for real deployments)

--- a/script/deployment/04_RegisterSingletons.s.sol
+++ b/script/deployment/04_RegisterSingletons.s.sol
@@ -16,6 +16,7 @@ contract RegisterSingletonsScript is Script, DeploymentManager {
     function run(address registryAddr, address assetRouterAddr, address minterAddr, address factoryAddr) public {
         // Read network configuration
         NetworkConfig memory config = readNetworkConfig();
+        validateConfig(config);
         DeploymentOutput memory existing;
 
         // If addresses not provided, read from JSON (for real deployments)

--- a/script/deployment/05_DeployTokens.s.sol
+++ b/script/deployment/05_DeployTokens.s.sol
@@ -29,6 +29,7 @@ contract DeployTokensScript is Script, DeploymentManager {
     {
         // Read network configuration
         NetworkConfig memory config = readNetworkConfig();
+        validateConfig(config);
         DeploymentOutput memory existing;
 
         // If registry not provided, read from JSON (for real deployments)

--- a/script/deployment/06_DeployVaultModules.s.sol
+++ b/script/deployment/06_DeployVaultModules.s.sol
@@ -16,6 +16,7 @@ contract DeployVaultModulesScript is Script, DeploymentManager {
     /// @return deployment Struct containing deployed module addresses
     function run(bool writeToJson) public returns (VaultModulesDeployment memory deployment) {
         NetworkConfig memory config = readNetworkConfig();
+        validateConfig(config);
 
         // Log script header and configuration
         logScriptHeader("06_DeployVaultModules");

--- a/script/deployment/07_DeployVaults.s.sol
+++ b/script/deployment/07_DeployVaults.s.sol
@@ -5,7 +5,6 @@ import { Script } from "forge-std/Script.sol";
 import { MinimalUUPSFactory } from "minimal-uups-factory/MinimalUUPSFactory.sol";
 
 import { DeploymentManager } from "../utils/DeploymentManager.sol";
-import { kRegistry } from "kam/src/kRegistry/kRegistry.sol";
 import { kStakingVault } from "kam/src/kStakingVault/kStakingVault.sol";
 import { ReaderModule } from "kam/src/kStakingVault/modules/ReaderModule.sol";
 
@@ -52,6 +51,7 @@ contract DeployVaultsScript is Script, DeploymentManager {
     {
         // Read network configuration
         config = readNetworkConfig();
+        validateConfig(config);
 
         // If addresses not provided, read from JSON (for real deployments)
         if (
@@ -108,34 +108,6 @@ contract DeployVaultsScript is Script, DeploymentManager {
         address dnVaultWBTC = _deployDNVaultWBTC();
         address alphaVault = _deployAlphaVault();
         address betaVault = _deployBetaVault();
-
-        _log("");
-        _log("=== SETTING BATCH LIMITS IN REGISTRY ===");
-
-        // Get registry reference
-        kRegistry registry = kRegistry(payable(registryAddr));
-        // Use registry to avoid unused variable warning
-        registry;
-
-        // Set batch limits for DN Vault USDC
-        _log("Setting batch limits for DN Vault USDC:");
-        _log("  Max Deposit:", config.dnVaultUSDC.maxDepositPerBatch);
-        _log("  Max Withdraw:", config.dnVaultUSDC.maxWithdrawPerBatch);
-
-        // Set batch limits for DN Vault WBTC
-        _log("Setting batch limits for DN Vault WBTC:");
-        _log("  Max Deposit:", config.dnVaultWBTC.maxDepositPerBatch);
-        _log("  Max Withdraw:", config.dnVaultWBTC.maxWithdrawPerBatch);
-
-        // Set batch limits for Alpha Vault
-        _log("Setting batch limits for Alpha Vault:");
-        _log("  Max Deposit:", config.alphaVault.maxDepositPerBatch);
-        _log("  Max Withdraw:", config.alphaVault.maxWithdrawPerBatch);
-
-        // Set batch limits for Beta Vault
-        _log("Setting batch limits for Beta Vault:");
-        _log("  Max Deposit:", config.betaVault.maxDepositPerBatch);
-        _log("  Max Withdraw:", config.betaVault.maxWithdrawPerBatch);
 
         // Register ReaderModule to all vaults
         _log("");

--- a/script/deployment/08_DeployAdapters.s.sol
+++ b/script/deployment/08_DeployAdapters.s.sol
@@ -35,6 +35,7 @@ contract DeployAdaptersScript is Script, DeploymentManager {
     {
         // Read network configuration
         NetworkConfig memory config = readNetworkConfig();
+        validateConfig(config);
         DeploymentOutput memory existing;
 
         // If addresses not provided, read from JSON (for real deployments)
@@ -68,46 +69,22 @@ contract DeployAdaptersScript is Script, DeploymentManager {
         // Deploy VaultAdapter implementation (shared by all adapters)
         VaultAdapter vaultAdapterImpl = new VaultAdapter();
 
-        // Deploy DN Vault USDC Adapter
-        bytes memory adapterInitDataUSDC = abi.encodeCall(
-            MinimalSmartAccount.initialize,
-            (
-                config.roles.owner, // owner (zero address = no specific owner, inherits from registry)
-                IRegistry(registryAddr),
-                "kam.dnVault.usdc"
-            )
+        address dnVaultAdapterUSDC = _deployAdapter(
+            factory, address(vaultAdapterImpl), registryAddr, config, config.adapters.dnVaultAdapterUSDC
         );
-        address dnVaultAdapterUSDC = factory.deployAndCall(address(vaultAdapterImpl), adapterInitDataUSDC);
-
-        // Deploy DN Vault WBTC Adapter
-        bytes memory adapterInitDataWBTC = abi.encodeCall(
-            MinimalSmartAccount.initialize, (config.roles.owner, IRegistry(registryAddr), "kam.dnVault.wbtc")
+        address dnVaultAdapterWBTC = _deployAdapter(
+            factory, address(vaultAdapterImpl), registryAddr, config, config.adapters.dnVaultAdapterWBTC
         );
-        address dnVaultAdapterWBTC = factory.deployAndCall(address(vaultAdapterImpl), adapterInitDataWBTC);
-
-        // Deploy Alpha Vault Adapter
-        bytes memory adapterInitDataAlpha = abi.encodeCall(
-            MinimalSmartAccount.initialize, (config.roles.owner, IRegistry(registryAddr), "kam.alphaVault.usdc")
+        address alphaVaultAdapter =
+            _deployAdapter(factory, address(vaultAdapterImpl), registryAddr, config, config.adapters.alphaVaultAdapter);
+        address betaVaultAdapter =
+            _deployAdapter(factory, address(vaultAdapterImpl), registryAddr, config, config.adapters.betaVaultAdapter);
+        address kMinterAdapterUSDC = _deployAdapter(
+            factory, address(vaultAdapterImpl), registryAddr, config, config.adapters.kMinterAdapterUSDC
         );
-        address alphaVaultAdapter = factory.deployAndCall(address(vaultAdapterImpl), adapterInitDataAlpha);
-
-        // Deploy Beta Vault Adapter
-        bytes memory adapterInitDataBeta = abi.encodeCall(
-            MinimalSmartAccount.initialize, (config.roles.owner, IRegistry(registryAddr), "kam.betaVault.usdc")
+        address kMinterAdapterWBTC = _deployAdapter(
+            factory, address(vaultAdapterImpl), registryAddr, config, config.adapters.kMinterAdapterWBTC
         );
-        address betaVaultAdapter = factory.deployAndCall(address(vaultAdapterImpl), adapterInitDataBeta);
-
-        // Deploy kMinter USDC Adapter
-        bytes memory adapterInitDataMinterUSDC = abi.encodeCall(
-            MinimalSmartAccount.initialize, (config.roles.owner, IRegistry(registryAddr), "kam.minter.usdc")
-        );
-        address kMinterAdapterUSDC = factory.deployAndCall(address(vaultAdapterImpl), adapterInitDataMinterUSDC);
-
-        // Deploy kMinter WBTC Adapter
-        bytes memory adapterInitDataMinterWBTC = abi.encodeCall(
-            MinimalSmartAccount.initialize, (config.roles.owner, IRegistry(registryAddr), "kam.minter.wbtc")
-        );
-        address kMinterAdapterWBTC = factory.deployAndCall(address(vaultAdapterImpl), adapterInitDataMinterWBTC);
 
         vm.stopBroadcast();
 
@@ -154,5 +131,22 @@ contract DeployAdaptersScript is Script, DeploymentManager {
     /// @notice Convenience wrapper for real deployments (writes to JSON, reads dependencies from JSON)
     function run() public returns (AdaptersDeployment memory) {
         return run(true, address(0), address(0));
+    }
+
+    function _deployAdapter(
+        MinimalUUPSFactory factory,
+        address vaultAdapterImpl,
+        address registryAddr,
+        NetworkConfig memory config,
+        AdapterConfig memory adapterConfig
+    )
+        private
+        returns (address)
+    {
+        bytes memory initData = abi.encodeCall(
+            MinimalSmartAccount.initialize,
+            (resolveAdapterOwner(config, adapterConfig), IRegistry(registryAddr), adapterConfig.namespace)
+        );
+        return factory.deployAndCall(vaultAdapterImpl, initData);
     }
 }

--- a/script/deployment/09_DeployInsuranceAccount.s.sol
+++ b/script/deployment/09_DeployInsuranceAccount.s.sol
@@ -40,6 +40,7 @@ contract DeployInsuranceAccountScript is Script, DeploymentManager {
     {
         // Read network configuration
         NetworkConfig memory config = readNetworkConfig();
+        validateConfig(config);
         DeploymentOutput memory existing;
 
         // If addresses not provided, read from JSON (for real deployments)

--- a/script/deployment/10_ConfigureProtocol.s.sol
+++ b/script/deployment/10_ConfigureProtocol.s.sol
@@ -39,11 +39,14 @@ contract ConfigureProtocolScript is Script, DeploymentManager {
     {
         // Read network configuration
         NetworkConfig memory config = readNetworkConfig();
+        validateConfigurationConfig(config);
         DeploymentOutput memory existing;
 
         // Use provided asset addresses or fall back to config
         _usdc = usdcAddr != address(0) ? usdcAddr : config.assets.USDC;
         _wbtc = wbtcAddr != address(0) ? wbtcAddr : config.assets.WBTC;
+        config.assets.USDC = _usdc;
+        config.assets.WBTC = _wbtc;
 
         // If any address is zero, read from JSON (for real deployments)
         if (
@@ -126,25 +129,28 @@ contract ConfigureProtocolScript is Script, DeploymentManager {
 
         _log("1. Registering vaults with kRegistry...");
 
-        // Register kMinter as MINTER vault type for both assets
-        registry.registerVault(minterAddr, IRegistry.VaultType.MINTER, _usdc);
-        _log("   - Registered kMinter as MINTER vault for USDC");
-        registry.registerVault(minterAddr, IRegistry.VaultType.MINTER, _wbtc);
-        _log("   - Registered kMinter as MINTER vault for WBTC");
+        IRegistry.VaultType minterVaultType = resolveVaultType(config.minter.vaultType);
+        registry.registerVault(minterAddr, minterVaultType, _usdc);
+        _log("   - Registered kMinter vault for USDC");
+        registry.registerVault(minterAddr, minterVaultType, _wbtc);
+        _log("   - Registered kMinter vault for WBTC");
 
-        // Register DN Vaults
-        registry.registerVault(dnVaultUSDCAddr, IRegistry.VaultType.DN, _usdc);
-        _log("   - Registered DN Vault USDC as DN vault for USDC");
-        registry.registerVault(dnVaultWBTCAddr, IRegistry.VaultType.DN, _wbtc);
-        _log("   - Registered DN Vault WBTC as DN vault for WBTC");
+        address dnVaultUSDCAsset = getUnderlyingAssetAddress(config, config.dnVaultUSDC.underlyingAsset);
+        address dnVaultWBTCAsset = getUnderlyingAssetAddress(config, config.dnVaultWBTC.underlyingAsset);
+        address alphaVaultAsset = getUnderlyingAssetAddress(config, config.alphaVault.underlyingAsset);
+        address betaVaultAsset = getUnderlyingAssetAddress(config, config.betaVault.underlyingAsset);
 
-        // Register Alpha Vault as ALPHA vault type
-        registry.registerVault(alphaVaultAddr, IRegistry.VaultType.ALPHA, _usdc);
-        _log("   - Registered Alpha Vault as ALPHA vault for USDC");
+        registry.registerVault(dnVaultUSDCAddr, resolveVaultType(config.dnVaultUSDC.vaultType), dnVaultUSDCAsset);
+        _log("   - Registered DN Vault USDC from config");
+        registry.registerVault(dnVaultWBTCAddr, resolveVaultType(config.dnVaultWBTC.vaultType), dnVaultWBTCAsset);
+        _log("   - Registered DN Vault WBTC from config");
+        registry.registerVault(alphaVaultAddr, resolveVaultType(config.alphaVault.vaultType), alphaVaultAsset);
+        _log("   - Registered Alpha Vault from config");
+        registry.registerVault(betaVaultAddr, resolveVaultType(config.betaVault.vaultType), betaVaultAsset);
+        _log("   - Registered Beta Vault from config");
 
-        // Register Beta Vault as BETA vault type
-        registry.registerVault(betaVaultAddr, IRegistry.VaultType.BETA, _usdc);
-        _log("   - Registered Beta Vault as BETA vault for USDC");
+        registry.setTreasuryBps(config.registry.treasuryBps);
+        registry.setInsuranceBps(config.registry.insuranceBps);
 
         // Set asset batch limits
         registry.setBatchLimits(
@@ -195,15 +201,15 @@ contract ConfigureProtocolScript is Script, DeploymentManager {
         _log("   - Registered kMinter WBTC Adapter for kMinter");
 
         // Register adapters for DN vaults
-        registry.registerAdapter(dnVaultUSDCAddr, _usdc, dnVaultAdapterUSDCAddr);
+        registry.registerAdapter(dnVaultUSDCAddr, dnVaultUSDCAsset, dnVaultAdapterUSDCAddr);
         _log("   - Registered DN Vault USDC Adapter for DN Vault USDC");
-        registry.registerAdapter(dnVaultWBTCAddr, _wbtc, dnVaultAdapterWBTCAddr);
+        registry.registerAdapter(dnVaultWBTCAddr, dnVaultWBTCAsset, dnVaultAdapterWBTCAddr);
         _log("   - Registered DN Vault WBTC Adapter for DN Vault WBTC");
 
         // Register adapters for Alpha and Beta vaults
-        registry.registerAdapter(alphaVaultAddr, _usdc, alphaVaultAdapterAddr);
+        registry.registerAdapter(alphaVaultAddr, alphaVaultAsset, alphaVaultAdapterAddr);
         _log("   - Registered Alpha Vault Adapter for Alpha Vault");
-        registry.registerAdapter(betaVaultAddr, _usdc, betaVaultAdapterAddr);
+        registry.registerAdapter(betaVaultAddr, betaVaultAsset, betaVaultAdapterAddr);
         _log("   - Registered Beta Vault Adapter for Beta Vault");
 
         _log("");

--- a/script/deployment/11_ConfigureExecutorPermissions.s.sol
+++ b/script/deployment/11_ConfigureExecutorPermissions.s.sol
@@ -159,6 +159,7 @@ contract ConfigureExecutorPermissionsScript is Script, DeploymentManager {
     {
         // Read network configuration
         NetworkConfig memory config = readNetworkConfig();
+        validateConfigurationConfig(config);
         DeploymentOutput memory existing;
 
         // Use provided asset addresses or fall back to config
@@ -176,7 +177,11 @@ contract ConfigureExecutorPermissionsScript is Script, DeploymentManager {
         if (dnVaultAdapterWBTCAddr == address(0)) dnVaultAdapterWBTCAddr = existing.contracts.dnVaultAdapterWBTC;
         if (alphaVaultAdapterAddr == address(0)) alphaVaultAdapterAddr = existing.contracts.alphaVaultAdapter;
         if (betaVaultAdapterAddr == address(0)) betaVaultAdapterAddr = existing.contracts.betaVaultAdapter;
-        if (walletUSDCAddr == address(0)) walletUSDCAddr = existing.contracts.WalletUSDC;
+        if (walletUSDCAddr == address(0)) {
+            walletUSDCAddr = config.custodialTargets.walletUSDC != address(0)
+                ? config.custodialTargets.walletUSDC
+                : existing.contracts.WalletUSDC;
+        }
 
         // For metawallet addresses: prefer config file (production), fallback to addresses.json (mocks)
         if (metawalletUSDCAddr == address(0)) {
@@ -295,7 +300,9 @@ contract ConfigureExecutorPermissionsScript is Script, DeploymentManager {
         _configureAllowedReceivers(erc20ExecutionValidator, config, existing, usdc, metawalletUSDCAddr, walletUSDCAddr);
 
         // Set allowed sources from config
-        _configureAllowedSources(erc20ExecutionValidator, config, existing, metawalletUSDCAddr, metawalletWBTCAddr);
+        _configureAllowedSources(
+            erc20ExecutionValidator, config, existing, usdc, wbtc, metawalletUSDCAddr, metawalletWBTCAddr
+        );
 
         // Set allowed spenders from config
         _configureAllowedSpenders(
@@ -323,8 +330,9 @@ contract ConfigureExecutorPermissionsScript is Script, DeploymentManager {
 
         // Write to JSON only if requested (for real deployments)
         if (writeToJson) {
-            writeContractAddress("erc20ExecutionValidator", address(erc20ExecutionValidator));
-            writeContractAddress("erc4626ExecutionValidator", address(erc4626ExecutionValidator));
+            queueContractAddress("erc20ExecutionValidator", address(erc20ExecutionValidator));
+            queueContractAddress("erc4626ExecutionValidator", address(erc4626ExecutionValidator));
+            flushContractAddresses();
         }
 
         _log("");
@@ -438,12 +446,30 @@ contract ConfigureExecutorPermissionsScript is Script, DeploymentManager {
         ERC20ExecutionValidator validator,
         NetworkConfig memory config,
         DeploymentOutput memory existing,
+        address usdc,
+        address wbtc,
         address usdcVault,
         address wbtcVault
     )
         internal
     {
         _log("   - Set allowed sources from config");
+
+        // USDC sources
+        for (uint256 i = 0; i < config.parameterChecker.allowedSources.USDC.length; i++) {
+            address source = _resolveAddress(config.parameterChecker.allowedSources.USDC[i], config, existing);
+            if (source != address(0)) {
+                validator.setAllowedSource(usdc, source, true);
+            }
+        }
+
+        // WBTC sources
+        for (uint256 i = 0; i < config.parameterChecker.allowedSources.WBTC.length; i++) {
+            address source = _resolveAddress(config.parameterChecker.allowedSources.WBTC[i], config, existing);
+            if (source != address(0)) {
+                validator.setAllowedSource(wbtc, source, true);
+            }
+        }
 
         // metawalletUSDC sources
         for (uint256 i = 0; i < config.parameterChecker.allowedSources.metawalletUSDC.length; i++) {

--- a/script/deployment/12_ConfigureAdapterApprovals.s.sol
+++ b/script/deployment/12_ConfigureAdapterApprovals.s.sol
@@ -43,6 +43,7 @@ contract ConfigureAdapterApprovalsScript is Script, DeploymentManager {
     {
         // Read network configuration
         NetworkConfig memory config = readNetworkConfig();
+        validateConfigurationConfig(config);
         DeploymentOutput memory existing;
 
         // Read deployment output for contract addresses
@@ -109,9 +110,11 @@ contract ConfigureAdapterApprovalsScript is Script, DeploymentManager {
 
         IkRegistry registry = IkRegistry(payable(registryAddr));
 
-        // Grant MANAGER_ROLE to admin so we can execute adapter calls
-        _log("Granting MANAGER_ROLE to admin for adapter execution...");
-        registry.grantManagerRole(config.roles.admin);
+        bool adminWasManager = registry.isManager(config.roles.admin);
+        if (!adminWasManager) {
+            _log("Granting temporary MANAGER_ROLE to admin for adapter execution...");
+            registry.grantManagerRole(config.roles.admin);
+        }
 
         _log("");
         _log("1. Approving metawallets to spend underlying assets from kMinter adapters...");
@@ -145,6 +148,12 @@ contract ConfigureAdapterApprovalsScript is Script, DeploymentManager {
         if (betaVaultAdapterAddr != address(0)) {
             _executeApproval(kMinterAdapterUSDCAddr, metawalletUSDCAddr, betaVaultAdapterAddr, maxApproval);
             _log("   - kMinterAdapterUSDC approved betaVaultAdapter to spend metawallet shares");
+        }
+
+        if (!adminWasManager) {
+            _log("");
+            _log("Revoking temporary MANAGER_ROLE from admin...");
+            registry.revokeManagerRole(config.roles.admin);
         }
 
         vm.stopBroadcast();

--- a/script/multichain/DeployRemoteRegistry.s.sol
+++ b/script/multichain/DeployRemoteRegistry.s.sol
@@ -25,6 +25,7 @@ contract DeployRemoteRegistryScript is Script, DeploymentManager {
     function run(bool writeToJson) public returns (RemoteRegistryDeployment memory deployment) {
         // Read network configuration from JSON
         NetworkConfig memory config = readNetworkConfig();
+        validateConfig(config);
 
         // Log script header and configuration
         logScriptHeader("DeployRemoteRegistry");

--- a/script/utils/DeploymentManager.sol
+++ b/script/utils/DeploymentManager.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import { Script } from "forge-std/Script.sol";
 import { stdJson } from "forge-std/StdJson.sol";
 import { console2 as console } from "forge-std/console2.sol";
+import { IERC20 } from "forge-std/interfaces/IERC20.sol";
+import { IRegistry } from "kam/src/interfaces/IRegistry.sol";
 
 abstract contract DeploymentManager is Script {
     using stdJson for string;
@@ -23,12 +25,14 @@ abstract contract DeploymentManager is Script {
         AssetAddresses assets;
         MetawalletAddresses metawallets;
         CustodialTargets custodialTargets;
+        MinterConfig minter;
         KTokenConfig kUSD;
         KTokenConfig kBTC;
         VaultConfig dnVaultUSDC;
         VaultConfig dnVaultWBTC;
         VaultConfig alphaVault;
         VaultConfig betaVault;
+        AdapterConfigs adapters;
         RegistryConfig registry;
         AssetRouterConfig assetRouter;
         ParameterCheckerConfig parameterChecker;
@@ -69,11 +73,16 @@ abstract contract DeploymentManager is Script {
         uint256 maxRedeemPerBatch;
     }
 
+    struct MinterConfig {
+        string vaultType;
+    }
+
     struct VaultConfig {
         string name;
         string symbol;
         uint8 decimals;
         string underlyingAsset;
+        string vaultType;
         bool startPaused;
         uint128 maxTotalAssets;
         uint256 maxDepositPerBatch;
@@ -81,6 +90,20 @@ abstract contract DeploymentManager is Script {
         address trustedForwarder;
         uint16 hurdleRate;
         bool isHardHurdleRate;
+    }
+
+    struct AdapterConfig {
+        string namespace;
+        string owner;
+    }
+
+    struct AdapterConfigs {
+        AdapterConfig dnVaultAdapterUSDC;
+        AdapterConfig dnVaultAdapterWBTC;
+        AdapterConfig alphaVaultAdapter;
+        AdapterConfig betaVaultAdapter;
+        AdapterConfig kMinterAdapterUSDC;
+        AdapterConfig kMinterAdapterWBTC;
     }
 
     struct RegistryConfig {
@@ -115,6 +138,8 @@ abstract contract DeploymentManager is Script {
     }
 
     struct AllowedSources {
+        string[] USDC;
+        string[] WBTC;
         string[] metawalletUSDC;
         string[] metawalletWBTC;
     }
@@ -255,6 +280,7 @@ abstract contract DeploymentManager is Script {
     bytes32 internal constant JK_METAWALLET_USDC = keccak256("metawalletUSDC");
     bytes32 internal constant JK_METAWALLET_WBTC = keccak256("metawalletWBTC");
     bytes32 internal constant JK_WALLET_USDC = keccak256("WalletUSDC");
+    bytes32 internal constant JK_WALLET_WBTC = keccak256("WalletWBTC");
 
     // Insurance
     bytes32 internal constant JK_ERC20_EXECUTION_VALIDATOR = keccak256("erc20ExecutionValidator");
@@ -334,14 +360,14 @@ abstract contract DeploymentManager is Script {
     }
 
     function _readCustodialTargets(string memory json, NetworkConfig memory config) private pure {
-        // Parse custodial wallet addresses (for CEFFU mock / real custody)
-        // Read from mockAssets.WalletUSDC for now (will migrate to custodialTargets later)
-        config.custodialTargets.walletUSDC = json.readAddress(".mockAssets.WalletUSDC");
-        // WBTC wallet can be same or different - add to config if needed
-        config.custodialTargets.walletWBTC = config.custodialTargets.walletUSDC; // Using same wallet for now
+        config.custodialTargets.walletUSDC = json.readAddress(".custodialTargets.walletUSDC");
+        config.custodialTargets.walletWBTC = json.readAddress(".custodialTargets.walletWBTC");
     }
 
-    function _readTokensAndVaults(string memory json, NetworkConfig memory config) private pure {
+    function _readTokensAndVaults(string memory json, NetworkConfig memory config) private view {
+        // Parse minter config
+        config.minter.vaultType = json.readStringOr(".minter.vaultType", "MINTER");
+
         // Parse kToken configs
         config.kUSD = _readKTokenConfig(json, ".kTokens.kUSD");
         config.kBTC = _readKTokenConfig(json, ".kTokens.kBTC");
@@ -351,6 +377,14 @@ abstract contract DeploymentManager is Script {
         config.dnVaultWBTC = _readVaultConfig(json, ".vaults.dnVaultWBTC");
         config.alphaVault = _readVaultConfig(json, ".vaults.alphaVault");
         config.betaVault = _readVaultConfig(json, ".vaults.betaVault");
+
+        // Parse adapter configs
+        config.adapters.dnVaultAdapterUSDC = _readAdapterConfig(json, ".adapters.dnVaultAdapterUSDC");
+        config.adapters.dnVaultAdapterWBTC = _readAdapterConfig(json, ".adapters.dnVaultAdapterWBTC");
+        config.adapters.alphaVaultAdapter = _readAdapterConfig(json, ".adapters.alphaVaultAdapter");
+        config.adapters.betaVaultAdapter = _readAdapterConfig(json, ".adapters.betaVaultAdapter");
+        config.adapters.kMinterAdapterUSDC = _readAdapterConfig(json, ".adapters.kMinterAdapterUSDC");
+        config.adapters.kMinterAdapterWBTC = _readAdapterConfig(json, ".adapters.kMinterAdapterWBTC");
     }
 
     function _readRouterAndMocks(string memory json, NetworkConfig memory config) private pure {
@@ -394,13 +428,21 @@ abstract contract DeploymentManager is Script {
         config.symbol = json.readString(string.concat(path, ".symbol"));
         config.decimals = uint8(json.readUint(string.concat(path, ".decimals")));
         config.underlyingAsset = json.readString(string.concat(path, ".underlyingAsset"));
+        config.vaultType = json.readString(string.concat(path, ".vaultType"));
         config.startPaused = json.readBool(string.concat(path, ".startPaused"));
-        config.maxTotalAssets = uint128(json.readUint(string.concat(path, ".maxTotalAssets")));
-        config.maxDepositPerBatch = uint128(json.readUint(string.concat(path, ".maxDepositPerBatch")));
-        config.maxWithdrawPerBatch = uint128(json.readUint(string.concat(path, ".maxWithdrawPerBatch")));
+        config.maxTotalAssets = uint128(_parseUintString(json.readString(string.concat(path, ".maxTotalAssets"))));
+        config.maxDepositPerBatch = _parseUintString(json.readString(string.concat(path, ".maxDepositPerBatch")));
+        config.maxWithdrawPerBatch = _parseUintString(json.readString(string.concat(path, ".maxWithdrawPerBatch")));
         config.trustedForwarder = json.readAddress(string.concat(path, ".trustedForwarder"));
         config.hurdleRate = uint16(json.readUint(string.concat(path, ".hurdleRate")));
         config.isHardHurdleRate = json.readBool(string.concat(path, ".isHardHurdleRate"));
+        return config;
+    }
+
+    function _readAdapterConfig(string memory json, string memory path) private view returns (AdapterConfig memory) {
+        AdapterConfig memory config;
+        config.namespace = json.readString(string.concat(path, ".namespace"));
+        config.owner = json.readStringOr(string.concat(path, ".owner"), "config:roles.owner");
         return config;
     }
 
@@ -429,6 +471,12 @@ abstract contract DeploymentManager is Script {
         config.allowedReceivers.metawalletWBTC = abi.decode(metawalletWbtcReceivers, (string[]));
 
         // Read allowed sources arrays
+        bytes memory usdcSources = json.parseRaw(".parameterChecker.allowedSources.USDC");
+        config.allowedSources.USDC = abi.decode(usdcSources, (string[]));
+
+        bytes memory wbtcSources = json.parseRaw(".parameterChecker.allowedSources.WBTC");
+        config.allowedSources.WBTC = abi.decode(wbtcSources, (string[]));
+
         bytes memory metawalletUsdcSources = json.parseRaw(".parameterChecker.allowedSources.metawalletUSDC");
         config.allowedSources.metawalletUSDC = abi.decode(metawalletUsdcSources, (string[]));
 
@@ -453,7 +501,7 @@ abstract contract DeploymentManager is Script {
 
     function _parseUintString(string memory str) private pure returns (uint256) {
         bytes memory b = bytes(str);
-        if (b.length == 1 && b[0] == 0x30) return 0; // "0"
+        require(b.length > 0, "Empty number string");
 
         uint256 result = 0;
         for (uint256 i = 0; i < b.length; i++) {
@@ -461,7 +509,7 @@ abstract contract DeploymentManager is Script {
             require(digit <= 9, "Invalid number string");
             result = result * 10 + digit;
         }
-        return result == 0 ? type(uint256).max : result;
+        return result;
     }
 
     function getUnderlyingAssetAddress(
@@ -478,6 +526,47 @@ abstract contract DeploymentManager is Script {
             return config.assets.WBTC;
         }
         revert("Unknown asset key");
+    }
+
+    function resolveVaultType(string memory vaultType) internal pure returns (IRegistry.VaultType) {
+        bytes32 h = keccak256(bytes(vaultType));
+        if (h == keccak256("MINTER")) return IRegistry.VaultType.MINTER;
+        if (h == keccak256("DN")) return IRegistry.VaultType.DN;
+        if (h == keccak256("ALPHA")) return IRegistry.VaultType.ALPHA;
+        if (h == keccak256("BETA")) return IRegistry.VaultType.BETA;
+        if (h == keccak256("GAMMA")) return IRegistry.VaultType.GAMMA;
+        if (h == keccak256("DELTA")) return IRegistry.VaultType.DELTA;
+        if (h == keccak256("EPSILON")) return IRegistry.VaultType.EPSILON;
+        if (h == keccak256("ZETA")) return IRegistry.VaultType.ZETA;
+        if (h == keccak256("ETA")) return IRegistry.VaultType.ETA;
+        if (h == keccak256("THETA")) return IRegistry.VaultType.THETA;
+        if (h == keccak256("IOTA")) return IRegistry.VaultType.IOTA;
+        if (h == keccak256("KAPPA")) return IRegistry.VaultType.KAPPA;
+        if (h == keccak256("LAMBDA")) return IRegistry.VaultType.LAMBDA;
+        if (h == keccak256("MU")) return IRegistry.VaultType.MU;
+        if (h == keccak256("NU")) return IRegistry.VaultType.NU;
+        if (h == keccak256("XI")) return IRegistry.VaultType.XI;
+        if (h == keccak256("OMICRON")) return IRegistry.VaultType.OMICRON;
+        if (h == keccak256("PI")) return IRegistry.VaultType.PI;
+        if (h == keccak256("RHO")) return IRegistry.VaultType.RHO;
+        if (h == keccak256("SIGMA")) return IRegistry.VaultType.SIGMA;
+        revert("Unknown vault type");
+    }
+
+    function resolveAdapterOwner(
+        NetworkConfig memory config,
+        AdapterConfig memory adapter
+    )
+        internal
+        pure
+        returns (address)
+    {
+        bytes32 h = keccak256(bytes(adapter.owner));
+        if (h == keccak256("config:roles.owner")) return config.roles.owner;
+        if (h == keccak256("config:roles.admin")) return config.roles.admin;
+        if (h == keccak256("config:roles.emergencyAdmin")) return config.roles.emergencyAdmin;
+        if (h == keccak256("config:roles.relayer")) return config.roles.relayer;
+        revert("Unknown adapter owner");
     }
 
     /// @notice Resolve an address from a string key using deployed contracts and config
@@ -509,7 +598,12 @@ abstract contract DeploymentManager is Script {
         if (h == JK_METAWALLET_WBTC) return existing.contracts.metawalletWBTC;
 
         // Custodial wallets
-        if (h == JK_WALLET_USDC_ALIAS) return existing.contracts.WalletUSDC;
+        if (h == JK_WALLET_USDC_ALIAS) {
+            return existing.contracts.WalletUSDC != address(0)
+                ? existing.contracts.WalletUSDC
+                : config.custodialTargets.walletUSDC;
+        }
+        if (h == JK_WALLET_WBTC_ALIAS) return config.custodialTargets.walletWBTC;
 
         // Core contracts
         if (h == JK_REGISTRY) return existing.contracts.kRegistry;
@@ -570,6 +664,9 @@ abstract contract DeploymentManager is Script {
         output.contracts.metawalletUSDC = json.readAddress(".contracts.metawalletUSDC");
         output.contracts.metawalletWBTC = json.readAddress(".contracts.metawalletWBTC");
         output.contracts.WalletUSDC = json.readAddress(".contracts.WalletUSDC");
+        if (json.keyExists(".contracts.WalletWBTC")) {
+            output.contracts.WalletWBTC = json.readAddress(".contracts.WalletWBTC");
+        }
         output.contracts.erc20ExecutionValidator = json.readAddress(".contracts.erc20ExecutionValidator");
         if (json.keyExists(".contracts.erc4626ExecutionValidator")) {
             output.contracts.erc4626ExecutionValidator = json.readAddress(".contracts.erc4626ExecutionValidator");
@@ -618,6 +715,7 @@ abstract contract DeploymentManager is Script {
 
         // Apply all pending updates
         for (uint256 i = 0; i < _pendingWriteCount; i++) {
+            _validateAddressUpdate(output, _pendingWrites[i].key, _pendingWrites[i].addr);
             _applyAddressUpdate(output, _pendingWrites[i].key, _pendingWrites[i].addr);
         }
 
@@ -670,6 +768,7 @@ abstract contract DeploymentManager is Script {
         else if (h == JK_METAWALLET_USDC) output.contracts.metawalletUSDC = contractAddress;
         else if (h == JK_METAWALLET_WBTC) output.contracts.metawalletWBTC = contractAddress;
         else if (h == JK_WALLET_USDC) output.contracts.WalletUSDC = contractAddress;
+        else if (h == JK_WALLET_WBTC) output.contracts.WalletWBTC = contractAddress;
         else if (h == JK_ERC20_EXECUTION_VALIDATOR) output.contracts.erc20ExecutionValidator = contractAddress;
         else if (h == JK_ERC4626_EXECUTION_VALIDATOR) output.contracts.erc4626ExecutionValidator = contractAddress;
         else if (h == JK_MINIMAL_SMART_ACCOUNT_IMPL) output.contracts.minimalSmartAccountImpl = contractAddress;
@@ -709,6 +808,7 @@ abstract contract DeploymentManager is Script {
         vm.serializeAddress(c, "metawalletUSDC", output.contracts.metawalletUSDC);
         vm.serializeAddress(c, "metawalletWBTC", output.contracts.metawalletWBTC);
         vm.serializeAddress(c, "WalletUSDC", output.contracts.WalletUSDC);
+        vm.serializeAddress(c, "WalletWBTC", output.contracts.WalletWBTC);
         vm.serializeAddress(c, "erc20ExecutionValidator", output.contracts.erc20ExecutionValidator);
         vm.serializeAddress(c, "erc4626ExecutionValidator", output.contracts.erc4626ExecutionValidator);
         vm.serializeAddress(c, "minimalSmartAccountImpl", output.contracts.minimalSmartAccountImpl);
@@ -723,7 +823,10 @@ abstract contract DeploymentManager is Script {
         return vm.serializeString(root, "contracts", contractsJson);
     }
 
-    function validateConfig(NetworkConfig memory config) internal pure {
+    function validateConfig(NetworkConfig memory config) internal view {
+        require(config.chainId == block.chainid, "Config chainId mismatch");
+        require(_stringsEqual(config.network, getCurrentNetwork()), "Config network mismatch");
+
         require(config.roles.owner != address(0), "Missing owner address");
         require(config.roles.admin != address(0), "Missing admin address");
         require(config.roles.emergencyAdmin != address(0), "Missing emergencyAdmin address");
@@ -734,6 +837,106 @@ abstract contract DeploymentManager is Script {
         require(config.roles.insurance != address(0), "Missing insurance address");
         require(config.assets.USDC != address(0), "Missing USDC address");
         require(config.assets.WBTC != address(0), "Missing WBTC address");
+
+        require(!_isPlaceholderAddress(config.roles.owner), "Placeholder owner address");
+        require(!_isPlaceholderAddress(config.roles.admin), "Placeholder admin address");
+        require(!_isPlaceholderAddress(config.roles.emergencyAdmin), "Placeholder emergencyAdmin address");
+        require(!_isPlaceholderAddress(config.roles.guardian), "Placeholder guardian address");
+        require(!_isPlaceholderAddress(config.roles.relayer), "Placeholder relayer address");
+        require(!_isPlaceholderAddress(config.roles.institution), "Placeholder institution address");
+        require(!_isPlaceholderAddress(config.roles.treasury), "Placeholder treasury address");
+        require(!_isPlaceholderAddress(config.roles.insurance), "Placeholder insurance address");
+        require(!_isPlaceholderAddress(config.assets.USDC), "Placeholder USDC address");
+        require(!_isPlaceholderAddress(config.assets.WBTC), "Placeholder WBTC address");
+
+        if (_stringsEqual(config.network, "mainnet")) {
+            _validateMainnetConfig(config);
+        } else if (!_stringsEqual(config.network, "localhost")) {
+            _validateNonLocalConfig(config);
+        }
+    }
+
+    function _validateNonLocalConfig(NetworkConfig memory config) private view {
+        require(config.assetRouter.settlementCooldown >= 1 hours, "Settlement cooldown too low");
+        require(config.assets.USDC.code.length > 0, "USDC has no code");
+        require(config.assets.WBTC.code.length > 0, "WBTC has no code");
+        require(IERC20(config.assets.USDC).decimals() == 6, "USDC decimals mismatch");
+        require(IERC20(config.assets.WBTC).decimals() == 8, "WBTC decimals mismatch");
+    }
+
+    function validateConfigurationConfig(NetworkConfig memory config) internal view {
+        validateConfig(config);
+        if (_stringsEqual(config.network, "localhost")) return;
+
+        require(config.metawallets.USDC != address(0), "Missing metawalletUSDC address");
+        require(config.metawallets.WBTC != address(0), "Missing metawalletWBTC address");
+        require(config.custodialTargets.walletUSDC != address(0), "Missing walletUSDC address");
+        require(config.custodialTargets.walletWBTC != address(0), "Missing walletWBTC address");
+        require(config.metawallets.USDC.code.length > 0, "metawalletUSDC has no code");
+        require(config.metawallets.WBTC.code.length > 0, "metawalletWBTC has no code");
+    }
+
+    function _validateMainnetConfig(NetworkConfig memory config) private view {
+        _validateNonLocalConfig(config);
+        require(config.assets.USDC == 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, "Invalid mainnet USDC");
+        require(config.assets.WBTC == 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599, "Invalid mainnet WBTC");
+    }
+
+    function _validateAddressUpdate(DeploymentOutput memory output, bytes32 h, address newAddress) private view {
+        if (_stringsEqual(getCurrentNetwork(), "localhost") || vm.envOr("ALLOW_REDEPLOY", false)) return;
+
+        address existingAddress = _getAddressByKey(output, h);
+        require(
+            existingAddress == address(0) || existingAddress == newAddress,
+            "Deployment output already has different address"
+        );
+    }
+
+    function _getAddressByKey(DeploymentOutput memory output, bytes32 h) private pure returns (address) {
+        if (h == JK_MINIMAL_UUPS_FACTORY) return output.contracts.MinimalUUPSFactory;
+        if (h == JK_REGISTRY_IMPL) return output.contracts.kRegistryImpl;
+        if (h == JK_REGISTRY) return output.contracts.kRegistry;
+        if (h == JK_MINTER_IMPL) return output.contracts.kMinterImpl;
+        if (h == JK_MINTER) return output.contracts.kMinter;
+        if (h == JK_ASSET_ROUTER_IMPL) return output.contracts.kAssetRouterImpl;
+        if (h == JK_ASSET_ROUTER) return output.contracts.kAssetRouter;
+        if (h == JK_USD) return output.contracts.kUSD;
+        if (h == JK_BTC) return output.contracts.kBTC;
+        if (h == JK_READER_MODULE) return output.contracts.readerModule;
+        if (h == JK_ADAPTER_GUARDIAN_MODULE || h == JK_EXECUTION_GUARDIAN_MODULE) {
+            return output.contracts.adapterGuardianModule;
+        }
+        if (h == JK_TOKEN_FACTORY) return output.contracts.kTokenFactory;
+        if (h == JK_STAKING_VAULT_IMPL) return output.contracts.kStakingVaultImpl;
+        if (h == JK_DN_VAULT_USDC) return output.contracts.dnVaultUSDC;
+        if (h == JK_DN_VAULT_WBTC) return output.contracts.dnVaultWBTC;
+        if (h == JK_ALPHA_VAULT) return output.contracts.alphaVault;
+        if (h == JK_BETA_VAULT) return output.contracts.betaVault;
+        if (h == JK_VAULT_ADAPTER_IMPL) return output.contracts.vaultAdapterImpl;
+        if (h == JK_DN_VAULT_ADAPTER_USDC) return output.contracts.dnVaultAdapterUSDC;
+        if (h == JK_DN_VAULT_ADAPTER_WBTC) return output.contracts.dnVaultAdapterWBTC;
+        if (h == JK_ALPHA_VAULT_ADAPTER) return output.contracts.alphaVaultAdapter;
+        if (h == JK_BETA_VAULT_ADAPTER) return output.contracts.betaVaultAdapter;
+        if (h == JK_MINTER_ADAPTER_USDC) return output.contracts.kMinterAdapterUSDC;
+        if (h == JK_MINTER_ADAPTER_WBTC) return output.contracts.kMinterAdapterWBTC;
+        if (h == JK_METAWALLET_USDC) return output.contracts.metawalletUSDC;
+        if (h == JK_METAWALLET_WBTC) return output.contracts.metawalletWBTC;
+        if (h == JK_WALLET_USDC) return output.contracts.WalletUSDC;
+        if (h == JK_WALLET_WBTC) return output.contracts.WalletWBTC;
+        if (h == JK_ERC20_EXECUTION_VALIDATOR) return output.contracts.erc20ExecutionValidator;
+        if (h == JK_ERC4626_EXECUTION_VALIDATOR) return output.contracts.erc4626ExecutionValidator;
+        if (h == JK_MINIMAL_SMART_ACCOUNT_IMPL) return output.contracts.minimalSmartAccountImpl;
+        if (h == JK_INSURANCE_SMART_ACCOUNT) return output.contracts.insuranceSmartAccount;
+        return address(0);
+    }
+
+    function _isPlaceholderAddress(address addr) private pure returns (bool) {
+        uint160 raw = uint160(addr);
+        return raw > 0 && raw <= 10;
+    }
+
+    function _stringsEqual(string memory a, string memory b) private pure returns (bool) {
+        return keccak256(bytes(a)) == keccak256(bytes(b));
     }
 
     function validateAdapterDeployments(DeploymentOutput memory existing) internal pure {
@@ -923,6 +1126,8 @@ abstract contract DeploymentManager is Script {
             config.parameterChecker.allowedReceivers.metawalletWBTC.length,
             "entries"
         );
+        console.log("Allowed Sources USDC:        ", config.parameterChecker.allowedSources.USDC.length, "entries");
+        console.log("Allowed Sources WBTC:        ", config.parameterChecker.allowedSources.WBTC.length, "entries");
         console.log(
             "Allowed Sources metawalletUSDC:  ", config.parameterChecker.allowedSources.metawalletUSDC.length, "entries"
         );

--- a/src/adapters/VaultAdapter.sol
+++ b/src/adapters/VaultAdapter.sol
@@ -123,8 +123,7 @@ contract VaultAdapter is SmartAdapterAccount, IVaultAdapter {
     /// @notice Ensures neither the local adapter pause nor the registry-wide global pause is active
     function _checkPaused(VaultAdapterStorage storage $) internal view {
         require(
-            !$.paused
-                && !IkRegistry(address(_getMinimalAccountStorage().registry)).isGlobalPaused(),
+            !$.paused && !IkRegistry(address(_getMinimalAccountStorage().registry)).isGlobalPaused(),
             VAULTADAPTER_IS_PAUSED
         );
     }

--- a/test/unit/DeploymentTest.t.sol
+++ b/test/unit/DeploymentTest.t.sol
@@ -7,6 +7,7 @@ import { DeploymentBaseTest } from "../utils/DeploymentBaseTest.sol";
 
 import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 import { IERC4626 } from "forge-std/interfaces/IERC4626.sol";
+import { ConfigureAdapterApprovalsScript } from "kam/script/deployment/12_ConfigureAdapterApprovals.s.sol";
 import { IRegistry } from "kam/src/interfaces/IRegistry.sol";
 import { IExecutionGuardian } from "kam/src/interfaces/modules/IExecutionGuardian.sol";
 import { OptimizedOwnableRoles } from "solady/auth/OptimizedOwnableRoles.sol";
@@ -102,6 +103,100 @@ contract DeploymentTest is DeploymentBaseTest {
         assertEq(registry.getVaultType(address(dnVault)), uint8(1), "DN Vault type incorrect"); // DN = 1
         assertEq(registry.getVaultType(address(alphaVault)), uint8(2), "Alpha Vault type incorrect"); // ALPHA = 2
         assertEq(registry.getVaultType(address(betaVault)), uint8(3), "Beta Vault type incorrect"); // BETA = 3
+    }
+
+    function test_deployAdapter_namespaces_fromConfig() public view {
+        assertEq(minterAdapterUSDC.accountId(), "kam.minter.usdc", "kMinter USDC adapter namespace incorrect");
+        assertEq(minterAdapterWBTC.accountId(), "kam.minter.wbtc", "kMinter WBTC adapter namespace incorrect");
+        assertEq(DNVaultAdapterUSDC.accountId(), "kam.dnVault.usdc", "DN USDC adapter namespace incorrect");
+        assertEq(ALPHAVaultAdapterUSDC.accountId(), "kam.alphaVault.usdc", "Alpha adapter namespace incorrect");
+        assertEq(BETHAVaultAdapterUSDC.accountId(), "kam.betaVault.usdc", "Beta adapter namespace incorrect");
+    }
+
+    function test_configureProtocol_vaultType_fromConfig() public view {
+        assertEq(registry.getVaultType(address(minter)), uint8(IRegistry.VaultType.MINTER), "Minter type incorrect");
+        assertEq(registry.getVaultType(address(dnVault)), uint8(IRegistry.VaultType.DN), "DN type incorrect");
+        assertEq(registry.getVaultType(address(alphaVault)), uint8(IRegistry.VaultType.ALPHA), "Alpha type incorrect");
+        assertEq(registry.getVaultType(address(betaVault)), uint8(IRegistry.VaultType.BETA), "Beta type incorrect");
+    }
+
+    function test_configureProtocol_vaultAssetPairing_fromConfig() public view {
+        assertEq(
+            registry.getVaultByAssetAndType(tokens.usdc, uint8(IRegistry.VaultType.DN)),
+            address(dnVault),
+            "DN USDC pairing incorrect"
+        );
+        assertEq(
+            registry.getVaultByAssetAndType(tokens.wbtc, uint8(IRegistry.VaultType.DN)),
+            _vaultsDeploy.dnVaultWBTC,
+            "DN WBTC pairing incorrect"
+        );
+        assertEq(
+            registry.getVaultByAssetAndType(tokens.usdc, uint8(IRegistry.VaultType.ALPHA)),
+            address(alphaVault),
+            "Alpha asset pairing incorrect"
+        );
+        assertEq(
+            registry.getVaultByAssetAndType(tokens.usdc, uint8(IRegistry.VaultType.BETA)),
+            address(betaVault),
+            "Beta asset pairing incorrect"
+        );
+    }
+
+    function test_insuranceBps_applied_orRemoved() public view {
+        assertEq(registry.getTreasuryBps(), 1000, "Treasury BPS not applied");
+        assertEq(registry.getInsuranceBps(), 500, "Insurance BPS not applied");
+    }
+
+    function test_configureProtocol_vaultBatchLimits_fromConfig() public view {
+        assertEq(registry.getMaxMintPerBatch(address(dnVault)), type(uint256).max, "DN USDC deposit limit incorrect");
+        assertEq(registry.getMaxBurnPerBatch(address(dnVault)), 50_000_000_000_000, "DN USDC withdraw limit incorrect");
+        assertEq(
+            registry.getMaxMintPerBatch(_vaultsDeploy.dnVaultWBTC), type(uint256).max, "DN WBTC deposit limit incorrect"
+        );
+        assertEq(
+            registry.getMaxBurnPerBatch(_vaultsDeploy.dnVaultWBTC), 2_000_000_000, "DN WBTC withdraw limit incorrect"
+        );
+        assertEq(registry.getMaxMintPerBatch(address(alphaVault)), type(uint256).max, "Alpha deposit limit incorrect");
+        assertEq(registry.getMaxBurnPerBatch(address(alphaVault)), 20_000_000_000_000, "Alpha withdraw limit incorrect");
+    }
+
+    function test_configureAdapterApprovals_revokesTemporaryManagerRole() public {
+        assertFalse(registry.isManager(users.admin), "admin should not start as manager");
+
+        ConfigureAdapterApprovalsScript approvalsScript = new ConfigureAdapterApprovalsScript();
+        approvalsScript.setVerbose(false);
+        approvalsScript.run(
+            address(registry),
+            address(minterAdapterUSDC),
+            address(minterAdapterWBTC),
+            address(DNVaultAdapterUSDC),
+            _adaptersDeploy.dnVaultAdapterWBTC,
+            address(ALPHAVaultAdapterUSDC),
+            address(BETHAVaultAdapterUSDC),
+            address(metawalletUSDC),
+            address(metawalletWBTC)
+        );
+
+        assertFalse(registry.isManager(users.admin), "temporary manager role should be revoked");
+    }
+
+    function test_configureExecutorPermissions_rawAllowedSources_fromConfig() public view {
+        assertTrue(
+            erc20ExecutionValidator.isAllowedSource(tokens.usdc, address(minterAdapterUSDC)),
+            "USDC minter adapter source not applied"
+        );
+        assertTrue(
+            erc20ExecutionValidator.isAllowedSource(tokens.usdc, address(DNVaultAdapterUSDC)),
+            "USDC DN adapter source not applied"
+        );
+        assertTrue(
+            erc20ExecutionValidator.isAllowedSource(tokens.wbtc, address(minterAdapterWBTC)),
+            "WBTC minter adapter source not applied"
+        );
+        assertTrue(
+            erc20ExecutionValidator.isAllowedSource(tokens.wbtc, users.treasury), "WBTC treasury source not applied"
+        );
     }
 
     function test_UserFunding() public view {

--- a/test/unit/kRegistry.t.sol
+++ b/test/unit/kRegistry.t.sol
@@ -1032,12 +1032,19 @@ contract kRegistryTest is DeploymentBaseTest {
         assertEq(_iBps, _insuranceBps);
     }
 
-    function test_getSettlementConfig_Returns_Defaults_When_Not_Set() public view {
+    function test_getSettlementConfig_Returns_Defaults_When_Not_Set() public {
+        kRegistry freshImpl = new kRegistry();
+        bytes memory initData = abi.encodeCall(
+            kRegistry.initialize,
+            (users.owner, users.admin, users.emergencyAdmin, users.guardian, users.relayer, users.treasury)
+        );
+        kRegistry freshRegistry = kRegistry(payable(factory.deployAndCall(address(freshImpl), initData)));
+
         (address _treasury, address _insurance, uint16 _treasuryBps, uint16 _insuranceBps) =
-            registry.getSettlementConfig();
+            freshRegistry.getSettlementConfig();
 
         assertEq(_treasury, users.treasury); // Set in initialize
-        assertEq(_insurance, insuranceSmartAccount); // Set during deployment via DeployInsuranceAccountScript
+        assertEq(_insurance, address(0)); // Not set
         assertEq(_treasuryBps, 0); // Not set
         assertEq(_insuranceBps, 0); // Not set
     }

--- a/test/utils/DeploymentBaseTest.sol
+++ b/test/utils/DeploymentBaseTest.sol
@@ -23,6 +23,8 @@ import { ReaderModule } from "kam/src/kStakingVault/modules/ReaderModule.sol";
 
 // Adapters
 import { VaultAdapter } from "kam/src/adapters/VaultAdapter.sol";
+import { ERC20ExecutionValidator } from "kam/src/adapters/parameters/ERC20ExecutionValidator.sol";
+import { ERC4626ExecutionValidator } from "kam/src/adapters/parameters/ERC4626ExecutionValidator.sol";
 
 // Interfaces
 import { IRegistry } from "kam/src/interfaces/IkRegistry.sol";
@@ -68,6 +70,8 @@ contract DeploymentBaseTest is BaseTest {
     VaultAdapter public BETHAVaultAdapterUSDC;
     VaultAdapter public vaultAdapter6;
     VaultAdapter public vaultAdapterImpl;
+    ERC20ExecutionValidator public erc20ExecutionValidator;
+    ERC4626ExecutionValidator public erc4626ExecutionValidator;
 
     // Insurance
     address public insuranceSmartAccount;
@@ -214,21 +218,24 @@ contract DeploymentBaseTest is BaseTest {
 
         ConfigureExecutorPermissionsScript executorPermissionsScript = new ConfigureExecutorPermissionsScript();
         executorPermissionsScript.setVerbose(false);
-        executorPermissionsScript.run(
-            false,
-            _registryDeploy.registry,
-            _adaptersDeploy.kMinterAdapterUSDC,
-            _adaptersDeploy.kMinterAdapterWBTC,
-            _adaptersDeploy.dnVaultAdapterUSDC,
-            _adaptersDeploy.dnVaultAdapterWBTC,
-            _adaptersDeploy.alphaVaultAdapter,
-            _adaptersDeploy.betaVaultAdapter,
-            _mocks.metawalletUSDC,
-            _mocks.metawalletWBTC,
-            _mocks.WalletUSDC,
-            _mocks.USDC,
-            _mocks.WBTC
-        );
+        ConfigureExecutorPermissionsScript.ExecutorPermissionsDeployment memory executorPermissionsDeploy =
+            executorPermissionsScript.run(
+                false,
+                _registryDeploy.registry,
+                _adaptersDeploy.kMinterAdapterUSDC,
+                _adaptersDeploy.kMinterAdapterWBTC,
+                _adaptersDeploy.dnVaultAdapterUSDC,
+                _adaptersDeploy.dnVaultAdapterWBTC,
+                _adaptersDeploy.alphaVaultAdapter,
+                _adaptersDeploy.betaVaultAdapter,
+                _mocks.metawalletUSDC,
+                _mocks.metawalletWBTC,
+                _mocks.WalletUSDC,
+                _mocks.USDC,
+                _mocks.WBTC
+            );
+        erc20ExecutionValidator = ERC20ExecutionValidator(executorPermissionsDeploy.erc20ExecutionValidator);
+        erc4626ExecutionValidator = ERC4626ExecutionValidator(executorPermissionsDeploy.erc4626ExecutionValidator);
 
         // Note: ReaderModule is already registered to vaults in 07_DeployVaults.s.sol
 


### PR DESCRIPTION
- Fix _parseUintString silent uint256.max fallback on zero result
- Reduce deploy profile optimizer_runs (5000->800) to keep bytecode under 24KB limit
- Add config validation: placeholder address detection, chain ID/network checks
- Add idempotency guards preventing redeployment of existing contracts
- Add mainnet USDC/WBTC address validation in config
- Add settlement cooldown >= 1 hour validation for non-local networks
- Fix config JSON inconsistencies: vault types, string-typed large numbers
- Fix mainnet USDC/WBTC addresses to correct canonical addresses
- Revoke temporary MANAGER_ROLE after adapter approval setup
- Add metawallet asset validation in executor permissions script
- Add --disable-code-size-limit to localhost deployment flags
- Add anvil-localhost Makefile target for reproducible local testing